### PR TITLE
Quick wins: All Reminders shortcut, notes on cards, drag-to-reorder, ekPriority dedup

### DIFF
--- a/Sources/PairwiseReminders/Services/RemindersManager.swift
+++ b/Sources/PairwiseReminders/Services/RemindersManager.swift
@@ -66,21 +66,10 @@ final class RemindersManager: ObservableObject {
     func applyPriorities(_ items: [ReminderItem]) throws {
         let total = items.count
         guard total > 0 else { return }
-
-        let quartile = max(total / 4, 1)
-
-        for (index, item) in items.enumerated() {
-            let priority: Int
-            if index < quartile          { priority = 1 }  // High
-            else if index < quartile * 2 { priority = 5 }  // Medium
-            else if index < quartile * 3 { priority = 9 }  // Low
-            else                         { priority = 0 }  // None
-
-            item.ekReminder.priority = priority
-            // Must stage each reminder via save before committing.
+        for item in items {
+            item.ekReminder.priority = item.ekPriority(totalCount: total)
             try store.save(item.ekReminder, commit: false)
         }
-
         try store.commit()
     }
 

--- a/Sources/PairwiseReminders/Views/ListPickerView.swift
+++ b/Sources/PairwiseReminders/Views/ListPickerView.swift
@@ -60,12 +60,19 @@ struct ListPickerView: View {
 
     private var listPickerContent: some View {
         VStack(spacing: 0) {
-            List(remindersManager.lists, id: \.calendarIdentifier) { list in
-                ListRow(
-                    list: list,
-                    isSelected: session.selectedListIDs.contains(list.calendarIdentifier),
-                    onToggle: { toggleList(list) }
-                )
+            List {
+                Section {
+                    AllRemindersRow(isSelected: isAllSelected, onToggle: toggleAll)
+                }
+                Section("Lists") {
+                    ForEach(remindersManager.lists, id: \.calendarIdentifier) { list in
+                        ListRow(
+                            list: list,
+                            isSelected: session.selectedListIDs.contains(list.calendarIdentifier),
+                            onToggle: { toggleList(list) }
+                        )
+                    }
+                }
             }
             .listStyle(.insetGrouped)
 
@@ -132,12 +139,23 @@ struct ListPickerView: View {
         !session.selectedListIDs.isEmpty
     }
 
+    private var isAllSelected: Bool {
+        !remindersManager.lists.isEmpty &&
+        session.selectedListIDs.count == remindersManager.lists.count
+    }
+
     private var selectedCount: String {
         let n = session.selectedListIDs.count
-        switch n {
-        case 0: return ""
-        case 1: return "1 List"
-        default: return "\(n) Lists"
+        if n == 0 { return "" }
+        if isAllSelected { return "All Reminders" }
+        return n == 1 ? "1 List" : "\(n) Lists"
+    }
+
+    private func toggleAll() {
+        if isAllSelected {
+            session.selectedListIDs.removeAll()
+        } else {
+            session.selectedListIDs = Set(remindersManager.lists.map(\.calendarIdentifier))
         }
     }
 
@@ -192,6 +210,34 @@ private struct ListRow: View {
                     .frame(width: 12, height: 12)
 
                 Text(list.title)
+                    .foregroundStyle(.primary)
+
+                Spacer()
+
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(isSelected ? .blue : Color(.tertiaryLabel))
+                    .font(.title3)
+                    .animation(.spring(response: 0.25), value: isSelected)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - All Reminders Row
+
+private struct AllRemindersRow: View {
+    let isSelected: Bool
+    let onToggle: () -> Void
+
+    var body: some View {
+        Button(action: onToggle) {
+            HStack(spacing: 12) {
+                Image(systemName: "tray.full.fill")
+                    .foregroundStyle(.blue)
+                    .frame(width: 12)
+
+                Text("All Reminders")
                     .foregroundStyle(.primary)
 
                 Spacer()

--- a/Sources/PairwiseReminders/Views/PairwiseView.swift
+++ b/Sources/PairwiseReminders/Views/PairwiseView.swift
@@ -221,6 +221,13 @@ private struct CardBody: View {
                     .lineLimit(2)
             }
 
+            if let notes = item.notes, !notes.isEmpty {
+                Text(notes)
+                    .font(.subheadline)
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(3)
+            }
+
             HStack(spacing: 12) {
                 Label(item.listName, systemImage: "list.bullet")
                     .font(.caption)

--- a/Sources/PairwiseReminders/Views/ResultsView.swift
+++ b/Sources/PairwiseReminders/Views/ResultsView.swift
@@ -65,11 +65,28 @@ struct ResultsView: View {
 
     private var rankedList: some View {
         List {
-            ForEach(Array(session.rankedItems.enumerated()), id: \.element.id) { index, item in
-                RankedRow(item: item, rank: index + 1, total: session.rankedItems.count)
+            ForEach(session.rankedItems) { item in
+                RankedRow(
+                    item: item,
+                    rank: (session.rankedItems.firstIndex(of: item) ?? 0) + 1,
+                    total: session.rankedItems.count
+                )
             }
+            .onMove(perform: moveItems)
         }
         .listStyle(.insetGrouped)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) { EditButton() }
+        }
+    }
+
+    private func moveItems(from source: IndexSet, to destination: Int) {
+        session.rankedItems.move(fromOffsets: source, toOffset: destination)
+        for i in session.rankedItems.indices {
+            session.rankedItems[i].sortRank = i
+        }
+        session.didApply = false
+        RankingStore.save(rankedItems: session.rankedItems, forLists: session.selectedListIDs)
     }
 
     private var bottomBar: some View {


### PR DESCRIPTION
Closes #14, #15, #16, #20. Also closes #7 (via #20).

## Changes

**#14 — "All Reminders" shortcut (`ListPickerView`)**
New top row selects/deselects all lists at once. Button label becomes "All Reminders" when everything is selected. Uses stock `List` section with an `AllRemindersRow` matching the style of existing `ListRow`.

**#15 — Notes on comparison cards (`PairwiseView`)**
`CardBody` now shows `item.notes` below AI reasoning (`.tertiary` style, 3-line limit) when the reminder has notes. Helps distinguish similarly-titled items during comparison.

**#16 — Drag-to-reorder in ResultsView**
`EditButton` added to the nav bar. `.onMove` on the `ForEach` lets the user drag items to adjust the ranking after the pairwise sort. After any reorder: `sortRank` is updated, `didApply` is reset (re-enables the Apply button), and the new order is saved to `RankingStore`.

**#20 — Deduplicate `ekPriority` logic**
`RemindersManager.applyPriorities` previously reimplemented the same quartile math as `ReminderItem.ekPriority(totalCount:)`. Now it just calls that method. Single source of truth. Closes #7.

## Test plan
- [ ] List picker: tap "All Reminders" → all lists check; tap again → all uncheck
- [ ] List picker: select lists individually → "All Reminders" auto-checks when all are selected
- [ ] Comparison cards: reminders with notes show them below AI reasoning
- [ ] Results: tap Edit → drag handles appear; drag an item → Apply button re-enables; quit and reopen → new order persists
- [ ] Apply tiered priorities → verify High/Medium/Low/None distribution is still correct