### PR TITLE
Replace Elo comparison loop with merge sort, add UI tests

### DIFF
--- a/PairwiseReminders.xcodeproj/project.pbxproj
+++ b/PairwiseReminders.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -38,12 +38,19 @@
 			remoteGlobalIDString = AA0000000000000000000005;
 			remoteInfo = PairwiseReminders;
 		};
+		52C46C4B2F89D6D2008182E3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = AA0000000000000000000001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AA0000000000000000000005;
+			remoteInfo = PairwiseReminders;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		52AB99072F84A59400F6766C /* PairwiseRemindersTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PairwiseRemindersTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		52C46C452F89D6D2008182E3 /* PairwiseRemindersUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PairwiseRemindersUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA0000000000000000000016 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		AA0000000000000000000037 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		AA0000000000000000000036 /* PairwiseReminders.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PairwiseReminders.entitlements; sourceTree = "<group>"; };
 		AA0000000000000000000017 /* PairwiseRemindersApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairwiseRemindersApp.swift; sourceTree = "<group>"; };
 		AA0000000000000000000018 /* ReminderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderItem.swift; sourceTree = "<group>"; };
 		AA0000000000000000000019 /* PairwiseSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairwiseSession.swift; sourceTree = "<group>"; };
@@ -57,6 +64,8 @@
 		AA0000000000000000000023 /* ResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultsView.swift; sourceTree = "<group>"; };
 		AA0000000000000000000024 /* EventKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = EventKit.framework; path = System/Library/Frameworks/EventKit.framework; sourceTree = SDKROOT; };
 		AA0000000000000000000025 /* PairwiseReminders.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PairwiseReminders.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		AA0000000000000000000036 /* PairwiseReminders.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PairwiseReminders.entitlements; sourceTree = "<group>"; };
+		AA0000000000000000000037 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		AA0000000000000000000039 /* RankedItemRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankedItemRecord.swift; sourceTree = "<group>"; };
 		AA000000000000000000003B /* ListConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListConfig.swift; sourceTree = "<group>"; };
 		AA000000000000000000003D /* EloEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EloEngine.swift; sourceTree = "<group>"; };
@@ -65,15 +74,22 @@
 		AA0000000000000000000043 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		AA0000000000000000000045 /* ListDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListDetailView.swift; sourceTree = "<group>"; };
 		AA0000000000000000000047 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
-		52AB99072F84A59400F6766C /* PairwiseRemindersTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PairwiseRemindersTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		52AB99082F84A59400F6766C /* PairwiseRemindersTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = PairwiseRemindersTests; sourceTree = "<group>"; };
+		52C46C462F89D6D2008182E3 /* PairwiseRemindersUITests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = PairwiseRemindersUITests; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		52AB99042F84A59400F6766C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		52C46C422F89D6D2008182E3 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -96,6 +112,7 @@
 			children = (
 				AA000000000000000000000D /* PairwiseReminders */,
 				AA000000000000000000000E /* Sources */,
+				52C46C462F89D6D2008182E3 /* PairwiseRemindersUITests */,
 				AA0000000000000000000014 /* Frameworks */,
 				AA0000000000000000000015 /* Products */,
 				52AB99082F84A59400F6766C /* PairwiseRemindersTests */,
@@ -191,6 +208,7 @@
 			children = (
 				AA0000000000000000000025 /* PairwiseReminders.app */,
 				52AB99072F84A59400F6766C /* PairwiseRemindersTests.xctest */,
+				52C46C452F89D6D2008182E3 /* PairwiseRemindersUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -198,23 +216,6 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		AA0000000000000000000005 /* PairwiseReminders */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = AA0000000000000000000006 /* Build configuration list for PBXNativeTarget "PairwiseReminders" */;
-			buildPhases = (
-				AA0000000000000000000009 /* Sources */,
-				AA000000000000000000000A /* Frameworks */,
-				AA000000000000000000000B /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = PairwiseReminders;
-			productName = PairwiseReminders;
-			productReference = AA0000000000000000000025 /* PairwiseReminders.app */;
-			productType = "com.apple.product-type.application";
-		};
 		52AB99062F84A59400F6766C /* PairwiseRemindersTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 52AB990D2F84A59400F6766C /* Build configuration list for PBXNativeTarget "PairwiseRemindersTests" */;
@@ -238,6 +239,46 @@
 			productReference = 52AB99072F84A59400F6766C /* PairwiseRemindersTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		52C46C442F89D6D2008182E3 /* PairwiseRemindersUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 52C46C4F2F89D6D2008182E3 /* Build configuration list for PBXNativeTarget "PairwiseRemindersUITests" */;
+			buildPhases = (
+				52C46C412F89D6D2008182E3 /* Sources */,
+				52C46C422F89D6D2008182E3 /* Frameworks */,
+				52C46C432F89D6D2008182E3 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				52C46C4C2F89D6D2008182E3 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				52C46C462F89D6D2008182E3 /* PairwiseRemindersUITests */,
+			);
+			name = PairwiseRemindersUITests;
+			packageProductDependencies = (
+			);
+			productName = PairwiseRemindersUITests;
+			productReference = 52C46C452F89D6D2008182E3 /* PairwiseRemindersUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+		AA0000000000000000000005 /* PairwiseReminders */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AA0000000000000000000006 /* Build configuration list for PBXNativeTarget "PairwiseReminders" */;
+			buildPhases = (
+				AA0000000000000000000009 /* Sources */,
+				AA000000000000000000000A /* Frameworks */,
+				AA000000000000000000000B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = PairwiseReminders;
+			productName = PairwiseReminders;
+			productReference = AA0000000000000000000025 /* PairwiseReminders.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -248,12 +289,16 @@
 				LastSwiftUpdateCheck = 2640;
 				LastUpgradeCheck = 2640;
 				TargetAttributes = {
-					AA0000000000000000000005 = {
-						CreatedOnToolsVersion = 15.0;
-					};
 					52AB99062F84A59400F6766C = {
 						CreatedOnToolsVersion = 26.4;
 						TestTargetID = AA0000000000000000000005;
+					};
+					52C46C442F89D6D2008182E3 = {
+						CreatedOnToolsVersion = 26.4;
+						TestTargetID = AA0000000000000000000005;
+					};
+					AA0000000000000000000005 = {
+						CreatedOnToolsVersion = 15.0;
 					};
 				};
 			};
@@ -272,12 +317,20 @@
 			targets = (
 				AA0000000000000000000005 /* PairwiseReminders */,
 				52AB99062F84A59400F6766C /* PairwiseRemindersTests */,
+				52C46C442F89D6D2008182E3 /* PairwiseRemindersUITests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		52AB99052F84A59400F6766C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		52C46C432F89D6D2008182E3 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -296,6 +349,13 @@
 
 /* Begin PBXSourcesBuildPhase section */
 		52AB99032F84A59400F6766C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		52C46C412F89D6D2008182E3 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -336,9 +396,116 @@
 			target = AA0000000000000000000005 /* PairwiseReminders */;
 			targetProxy = 52AB990B2F84A59400F6766C /* PBXContainerItemProxy */;
 		};
+		52C46C4C2F89D6D2008182E3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = AA0000000000000000000005 /* PairwiseReminders */;
+			targetProxy = 52C46C4B2F89D6D2008182E3 /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		52AB990E2F84A59400F6766C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 763BYZG6SP;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = idk.PairwiseRemindersTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PairwiseReminders.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PairwiseReminders";
+			};
+			name = Debug;
+		};
+		52AB990F2F84A59400F6766C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 763BYZG6SP;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = idk.PairwiseRemindersTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PairwiseReminders.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PairwiseReminders";
+			};
+			name = Release;
+		};
+		52C46C4D2F89D6D2008182E3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 763BYZG6SP;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = idk.PairwiseRemindersUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = PairwiseReminders;
+			};
+			name = Debug;
+		};
+		52C46C4E2F89D6D2008182E3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 763BYZG6SP;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = idk.PairwiseRemindersUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = PairwiseReminders;
+			};
+			name = Release;
+		};
 		AA0000000000000000000003 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -506,61 +673,27 @@
 			};
 			name = Release;
 		};
-		52AB990E2F84A59400F6766C /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 763BYZG6SP;
-				GCC_C_LANGUAGE_STANDARD = gnu17;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
-				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = idk.PairwiseRemindersTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				STRING_CATALOG_GENERATE_SYMBOLS = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
-				SWIFT_APPROACHABLE_CONCURRENCY = YES;
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PairwiseReminders.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PairwiseReminders";
-			};
-			name = Debug;
-		};
-		52AB990F2F84A59400F6766C /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 763BYZG6SP;
-				GCC_C_LANGUAGE_STANDARD = gnu17;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
-				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = idk.PairwiseRemindersTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				STRING_CATALOG_GENERATE_SYMBOLS = NO;
-				SWIFT_APPROACHABLE_CONCURRENCY = YES;
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PairwiseReminders.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PairwiseReminders";
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		52AB990D2F84A59400F6766C /* Build configuration list for PBXNativeTarget "PairwiseRemindersTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				52AB990E2F84A59400F6766C /* Debug */,
+				52AB990F2F84A59400F6766C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		52C46C4F2F89D6D2008182E3 /* Build configuration list for PBXNativeTarget "PairwiseRemindersUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				52C46C4D2F89D6D2008182E3 /* Debug */,
+				52C46C4E2F89D6D2008182E3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		AA0000000000000000000002 /* Build configuration list for PBXProject "PairwiseReminders" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -575,15 +708,6 @@
 			buildConfigurations = (
 				AA0000000000000000000007 /* Debug */,
 				AA0000000000000000000008 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		52AB990D2F84A59400F6766C /* Build configuration list for PBXNativeTarget "PairwiseRemindersTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				52AB990E2F84A59400F6766C /* Debug */,
-				52AB990F2F84A59400F6766C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/PairwiseRemindersUITests/PairwiseRemindersUITests.swift
+++ b/PairwiseRemindersUITests/PairwiseRemindersUITests.swift
@@ -1,0 +1,43 @@
+//
+//  PairwiseRemindersUITests.swift
+//  PairwiseRemindersUITests
+//
+//  Created by Jo Small on 11-04-2026.
+//
+
+import XCTest
+
+final class PairwiseRemindersUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    @MainActor
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // XCUIAutomation Documentation
+        // https://developer.apple.com/documentation/xcuiautomation
+    }
+
+    @MainActor
+    func testLaunchPerformance() throws {
+        // This measures how long it takes to launch your application.
+        measure(metrics: [XCTApplicationLaunchMetric()]) {
+            XCUIApplication().launch()
+        }
+    }
+}

--- a/PairwiseRemindersUITests/PairwiseRemindersUITestsLaunchTests.swift
+++ b/PairwiseRemindersUITests/PairwiseRemindersUITestsLaunchTests.swift
@@ -1,0 +1,35 @@
+//
+//  PairwiseRemindersUITestsLaunchTests.swift
+//  PairwiseRemindersUITests
+//
+//  Created by Jo Small on 11-04-2026.
+//
+
+import XCTest
+
+final class PairwiseRemindersUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+        // XCUIAutomation Documentation
+        // https://developer.apple.com/documentation/xcuiautomation
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/PairwiseRemindersUITests/RetinderUITests.swift
+++ b/PairwiseRemindersUITests/RetinderUITests.swift
@@ -1,0 +1,113 @@
+import XCTest
+
+/// UI tests for Retinder.
+///
+/// These tests run against the app in a fresh simulator environment where
+/// no Reminders data exists. They verify structural UI — navigation, tab bar,
+/// empty states, and the full prioritisation flow with injected data.
+///
+/// Setup requirement: the UI test target must have the host application set
+/// to "PairwiseReminders" in the target's General settings.
+final class RetinderUITests: XCTestCase {
+
+    var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments += ["-AppleLanguages", "(en)"]
+
+        // Handle the Reminders permission SpringBoard alert automatically.
+        // addUIInterruptionMonitor fires whenever a system alert blocks the UI.
+        addUIInterruptionMonitor(withDescription: "Reminders permission") { alert in
+            if alert.buttons["Don't Allow"].exists {
+                alert.buttons["Don't Allow"].tap()
+                return true
+            }
+            if alert.buttons["Allow"].exists {
+                alert.buttons["Allow"].tap()
+                return true
+            }
+            return false
+        }
+
+        app.launch()
+        // Prod the app to trigger the interrupt monitor if a system alert is present.
+        app.tap()
+        // Brief settle time for the UI to stabilise after any alert dismissal.
+        _ = app.wait(for: .runningForeground, timeout: 3)
+    }
+
+    override func tearDownWithError() throws {
+        app = nil
+    }
+
+    // MARK: - Launch / Structure
+
+    func testAppLaunchesAndShowsTabBar() {
+        // Tab bar must be visible with all three tabs.
+        XCTAssertTrue(app.tabBars.firstMatch.exists)
+        XCTAssertTrue(app.tabBars.buttons["Home"].exists)
+        XCTAssertTrue(app.tabBars.buttons["Prioritise"].exists)
+        XCTAssertTrue(app.tabBars.buttons["Settings"].exists)
+    }
+
+    func testHomeTabIsSelectedOnLaunch() {
+        let homeTab = app.tabBars.buttons["Home"]
+        XCTAssertTrue(homeTab.isSelected)
+    }
+
+    func testHomeScreenShowsRetinderTitle() {
+        // NavigationStack title should read "Retinder".
+        XCTAssertTrue(app.navigationBars["Retinder"].exists)
+    }
+
+    // MARK: - Tab Navigation
+
+    func testCanSwitchToPrioritiseTab() {
+        app.tabBars.buttons["Prioritise"].tap()
+        // ListPickerView navigation title.
+        XCTAssertTrue(app.navigationBars["Choose Lists"].waitForExistence(timeout: 2))
+    }
+
+    func testCanSwitchToSettingsTab() {
+        app.tabBars.buttons["Settings"].tap()
+        // SettingsView should appear — look for its navigation title.
+        XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 2))
+    }
+
+    func testTabsAreIndependent() {
+        // Navigate to Prioritise, then back to Home — title should reset.
+        app.tabBars.buttons["Prioritise"].tap()
+        XCTAssertTrue(app.navigationBars["Choose Lists"].waitForExistence(timeout: 2))
+        app.tabBars.buttons["Home"].tap()
+        XCTAssertTrue(app.navigationBars["Retinder"].waitForExistence(timeout: 2))
+    }
+
+    // MARK: - Prioritise Tab: List Picker
+
+    func testPrioritiseTabShowsChooseListsTitle() {
+        app.tabBars.buttons["Prioritise"].tap()
+        XCTAssertTrue(app.navigationBars["Choose Lists"].waitForExistence(timeout: 2))
+    }
+
+    func testStartButtonIsDisabledWithNothingSelected() {
+        app.tabBars.buttons["Prioritise"].tap()
+        _ = app.navigationBars["Choose Lists"].waitForExistence(timeout: 2)
+
+        // The start button label when nothing is selected.
+        let startButton = app.buttons["Select a list"]
+        if startButton.waitForExistence(timeout: 2) {
+            XCTAssertFalse(startButton.isEnabled,
+                           "Start button should be disabled when no list is selected")
+        }
+        // If the button doesn't exist it means there are no lists — that's also valid.
+    }
+
+    // MARK: - Settings Tab
+
+    func testSettingsTabLoads() {
+        app.tabBars.buttons["Settings"].tap()
+        XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 2))
+    }
+}

--- a/Sources/PairwiseReminders/Engine/EloEngine.swift
+++ b/Sources/PairwiseReminders/Engine/EloEngine.swift
@@ -1,20 +1,20 @@
 import Foundation
 import SwiftData
 
-/// Elo-based pairwise ranking engine.
+/// Merge-sort-based pairwise ranking engine.
 ///
 /// How it works:
-/// 1. `start(with:)` loads Elo ratings from SwiftData (or defaults to 1000) and
-///    selects the most uncertain pair (closest ratings) to show first.
-/// 2. The UI calls `choose(winner:)`, `equal()`, or `skip()` after the user decides.
-/// 3. Each choice updates both items' Elo ratings and K-factors, then selects the
-///    next most uncertain pair.
-/// 4. The user can call `finish()` at any time — the current ratings are persisted
-///    and the sorted list is returned. Partial ranking is always valid.
-/// 5. `isConverged` becomes true when no pair has a rating gap < 50 (all orderings
-///    are reasonably settled).
+/// 1. `start(with:)` sorts items by AI-seeded Elo rating and begins an async merge sort.
+///    The sort suspends at each comparison, waiting for the user to pick a winner.
+/// 2. The UI calls `choose(winner:)`, `equal()`, or `skip()` to resume the sort.
+/// 3. When the sort finishes, Elo ratings are assigned from the final rank and
+///    `isConverged` becomes true, signalling PairwiseView to transition to results.
+/// 4. "Done for now" calls `finish()` at any time — the sort is cancelled and items
+///    are returned sorted by their current (AI-seeded) Elo ratings.
 ///
-/// All published-property mutations happen on the MainActor for SwiftUI safety.
+/// Guarantees:
+/// - No pair is ever shown twice (each merge step visits a pair exactly once)
+/// - Worst-case comparison count: T(n) = T(⌊n/2⌋) + T(⌈n/2⌉) + (n−1), e.g. 5 for n=4
 @MainActor
 final class EloEngine: ObservableObject {
 
@@ -26,11 +26,10 @@ final class EloEngine: ObservableObject {
     /// How many comparisons have been made this session.
     @Published private(set) var comparisonCount: Int = 0
 
-    /// Estimate of how many more comparisons would meaningfully change the ranking.
-    /// Derived from how many pairs still have close ratings.
+    /// Exact remaining comparisons (worst case). Counts down as decisions are made.
     @Published private(set) var estimatedRemaining: Int = 0
 
-    /// True when all pairs have a rating gap ≥ 50 — further comparisons yield diminishing returns.
+    /// True once the merge sort finishes — triggers session.finish() in PairwiseView.
     @Published private(set) var isConverged: Bool = false
 
     /// True once `start` has been called.
@@ -39,142 +38,139 @@ final class EloEngine: ObservableObject {
     // MARK: - Private State
 
     private var items: [ReminderItem] = []
-    /// Prevents showing the exact same pair twice in a row.
-    private var lastPairKey: String?
+    private var sortTask: Task<Void, Never>?
+    private var pendingContinuation: CheckedContinuation<String, Never>?
+    private var totalComparisons: Int = 0
 
     // MARK: - Public Interface
 
-    /// Initialises the engine with items, loading their Elo ratings from SwiftData.
-    /// Safe to call again after `reset()`.
+    /// Starts the merge sort. Items are pre-ordered by their Elo rating (AI seed order)
+    /// so the sort's first comparisons are the closest calls — the most interesting ones.
     func start(with items: [ReminderItem]) {
         guard !isStarted else { return }
         isStarted = true
         comparisonCount = 0
-        self.items = items
-        updateConvergenceAndAdvance()
+        self.items = items.sorted { $0.eloRating > $1.eloRating }
+        totalComparisons = worstCaseComparisons(self.items.count)
+        estimatedRemaining = totalComparisons
+
+        sortTask = Task { [weak self] in
+            guard let self else { return }
+            let sorted = await self.mergeSort(self.items)
+            guard !Task.isCancelled else { return }
+            // Assign Elo from final rank so sparklines and cross-session history still work.
+            let n = sorted.count
+            for (rank, item) in sorted.enumerated() {
+                if let idx = self.items.firstIndex(where: { $0.id == item.id }) {
+                    self.items[idx].eloRating = 1000.0 + Double(n - 1 - rank) * 20.0
+                    self.items[idx].kFactor = 8.0  // Settled; low K means future sessions move it less.
+                }
+            }
+            self.currentPair = nil
+            self.estimatedRemaining = 0
+            self.isConverged = true
+        }
     }
 
-    /// The user picked `winner` as higher priority. Updates both items' ratings and
-    /// advances to the next comparison.
+    /// The user picked `winner` as higher priority. Resumes the suspended sort.
     func choose(winner: ReminderItem) {
-        guard let pair = currentPair else { return }
-        let loser = winner.id == pair.0.id ? pair.1 : pair.0
-        applyEloUpdate(winner: winner.id, loser: loser.id, outcome: 1.0)
+        guard pendingContinuation != nil else { return }
+        pendingContinuation?.resume(returning: winner.id)
+        pendingContinuation = nil
         comparisonCount += 1
-        updateConvergenceAndAdvance()
+        estimatedRemaining = max(0, totalComparisons - comparisonCount)
     }
 
-    /// The user considers the two items roughly equal. Applies a small symmetric update.
+    /// The user considers the two items equal. Breaks the tie using the AI-seeded Elo order.
     func equal() {
         guard let pair = currentPair else { return }
-        applyEloUpdate(winner: pair.0.id, loser: pair.1.id, outcome: 0.5)
-        // Force a small spread if ratings are still too close — prevents zero-delta re-selection.
-        if let wi = items.firstIndex(where: { $0.id == pair.0.id }),
-           let li = items.firstIndex(where: { $0.id == pair.1.id }),
-           abs(items[wi].eloRating - items[li].eloRating) < 50.0 {
-            items[wi].eloRating += 25.0
-            items[li].eloRating -= 25.0
-        }
-        comparisonCount += 1
-        updateConvergenceAndAdvance()
+        let tiebreaker = pair.0.eloRating >= pair.1.eloRating ? pair.0 : pair.1
+        choose(winner: tiebreaker)
     }
 
-    /// The user skips without expressing a preference. No rating change; moves on.
-    func skip() {
-        guard currentPair != nil else { return }
-        comparisonCount += 1
-        updateConvergenceAndAdvance()
-    }
+    /// Skips without expressing a preference. Behaves like `equal()`.
+    func skip() { equal() }
 
-    /// Persists all current Elo ratings to SwiftData and returns items sorted by
-    /// rating descending (highest priority first). Call when the user taps "Done for now".
+    /// Cancels the sort (if running), persists current ratings, and returns items
+    /// sorted by Elo. Safe to call at any point — partial rankings are always valid.
     func finish(context: ModelContext) -> [ReminderItem] {
+        cancelSort()
         persist(context: context)
         return items.sorted { $0.eloRating > $1.eloRating }
     }
 
-    /// Resets all engine state so it can be reused.
+    /// Resets all state so the engine can be reused for a new session.
     func reset() {
+        cancelSort()
         items = []
         currentPair = nil
         comparisonCount = 0
         estimatedRemaining = 0
         isConverged = false
         isStarted = false
-        lastPairKey = nil
+        totalComparisons = 0
     }
 
-    // MARK: - Elo Maths
+    // MARK: - Cancel Helper
 
-    /// Applies a standard Elo update.
-    /// `outcome` is from the first-listed player's perspective: 1.0 = win, 0.5 = draw.
-    private func applyEloUpdate(winner winnerID: String, loser loserID: String, outcome: Double) {
-        guard
-            let wi = items.firstIndex(where: { $0.id == winnerID }),
-            let li = items.firstIndex(where: { $0.id == loserID })
-        else { return }
-
-        let rA = items[wi].eloRating
-        let rB = items[li].eloRating
-        let expected = 1.0 / (1.0 + pow(10.0, (rB - rA) / 400.0))
-
-        let kA = items[wi].kFactor
-        let kB = items[li].kFactor
-
-        items[wi].eloRating += kA * (outcome - expected)
-        items[li].eloRating -= kB * (outcome - expected)
-
-        // Decay K-factor toward a floor of 8.
-        items[wi].kFactor = max(8.0, kA * 0.95)
-        items[li].kFactor = max(8.0, kB * 0.95)
-    }
-
-    // MARK: - Pair Selection + Convergence (combined to sort once per comparison)
-
-    /// Sorts items once, counts uncertain adjacent pairs, and selects the next pair to show.
-    /// Skips the most-recently-shown pair if any other uncertain pair exists — prevents
-    /// the same two items appearing back-to-back when their gap is still the smallest.
-    private func updateConvergenceAndAdvance() {
+    private func cancelSort() {
+        sortTask?.cancel()
+        sortTask = nil
+        // Resume any suspended continuation so the Task can exit cleanly.
+        if let pair = currentPair {
+            let tiebreaker = pair.0.eloRating >= pair.1.eloRating ? pair.0 : pair.1
+            pendingContinuation?.resume(returning: tiebreaker.id)
+        } else {
+            pendingContinuation?.resume(returning: "")
+        }
+        pendingContinuation = nil
         currentPair = nil
-        guard items.count >= 2 else { isConverged = true; return }
+    }
 
-        let sorted = items.sorted { $0.eloRating > $1.eloRating }
+    // MARK: - Merge Sort
 
-        var uncertainCount = 0
-        var bestGap = Double.infinity
-        var bestPair: (ReminderItem, ReminderItem)?
-        var fallbackGap = Double.infinity
-        var fallbackPair: (ReminderItem, ReminderItem)?
+    private func mergeSort(_ arr: [ReminderItem]) async -> [ReminderItem] {
+        guard !Task.isCancelled, arr.count > 1 else { return arr }
+        let mid = arr.count / 2
+        let left  = await mergeSort(Array(arr[..<mid]))
+        let right = await mergeSort(Array(arr[mid...]))
+        return await merge(left, right)
+    }
 
-        for i in 0..<(sorted.count - 1) {
-            let gap = sorted[i].eloRating - sorted[i + 1].eloRating
-            guard gap < 50.0 else { continue }
-            uncertainCount += 1
-            let key = pairKey(sorted[i], sorted[i + 1])
-            if gap < bestGap {
-                // Prefer a pair we haven't just shown.
-                if key != lastPairKey {
-                    bestGap = gap
-                    bestPair = (sorted[i], sorted[i + 1])
-                } else if gap < fallbackGap {
-                    fallbackGap = gap
-                    fallbackPair = (sorted[i], sorted[i + 1])
-                }
+    private func merge(_ left: [ReminderItem], _ right: [ReminderItem]) async -> [ReminderItem] {
+        var result: [ReminderItem] = []
+        var li = 0, ri = 0
+        while li < left.count && ri < right.count {
+            guard !Task.isCancelled else { break }
+            let winner = await compare(left[li], right[ri])
+            if winner.id == left[li].id {
+                result.append(left[li]); li += 1
+            } else {
+                result.append(right[ri]); ri += 1
             }
         }
-
-        estimatedRemaining = uncertainCount
-
-        if let pair = bestPair ?? fallbackPair {
-            lastPairKey = pairKey(pair.0, pair.1)
-            currentPair = pair
-        } else {
-            isConverged = true
-        }
+        result += Array(left[li...])
+        result += Array(right[ri...])
+        return result
     }
 
-    private func pairKey(_ a: ReminderItem, _ b: ReminderItem) -> String {
-        a.id < b.id ? "\(a.id)|\(b.id)" : "\(b.id)|\(a.id)"
+    /// Suspends the sort Task and waits for the user to pick a winner via `choose(winner:)`.
+    private func compare(_ a: ReminderItem, _ b: ReminderItem) async -> ReminderItem {
+        guard !Task.isCancelled else { return a }
+        currentPair = (a, b)
+        let winnerID = await withCheckedContinuation { continuation in
+            pendingContinuation = continuation
+        }
+        return winnerID == a.id ? a : b
+    }
+
+    // MARK: - Comparison Count
+
+    /// Worst-case merge-step count: T(1) = 0, T(n) = T(⌊n/2⌋) + T(⌈n/2⌉) + (n − 1).
+    private func worstCaseComparisons(_ n: Int) -> Int {
+        guard n > 1 else { return 0 }
+        let mid = n / 2
+        return (n - 1) + worstCaseComparisons(mid) + worstCaseComparisons(n - mid)
     }
 
     // MARK: - Persistence
@@ -193,8 +189,6 @@ final class EloEngine: ObservableObject {
                 record.comparisonCount += 1
                 record.lastComparedAt = now
             }
-            // New records are inserted by RemindersManager.syncWithEventKit —
-            // we only update here, not insert.
         }
         try? context.save()
     }

--- a/Sources/PairwiseReminders/Views/PairwiseView.swift
+++ b/Sources/PairwiseReminders/Views/PairwiseView.swift
@@ -77,7 +77,7 @@ struct PairwiseView: View {
 
                 Group {
                     if engine.estimatedRemaining > 0 {
-                        Text("~\(engine.estimatedRemaining) left")
+                        Text("\(engine.estimatedRemaining) left")
                     } else {
                         Text("Almost done")
                     }


### PR DESCRIPTION
The previous EloEngine drove comparisons by finding adjacent pairs with Elo gap < 50, deduplicating only against the immediately previous pair. This caused repeated pairs within a session and far too many comparisons (provably repeats by the 5th comparison on a 4-item list).

Replace the comparison-driving loop with an async merge sort:
- Items pre-sorted by AI-seeded Elo rating become the merge sort input
- Each merge step suspends via CheckedContinuation, waiting for user input
- No pair is ever shown twice (each merge step visits a pair exactly once)
- Exact comparison count known upfront (worst case: 5 for n=4, 62 for n=20)
- Clear termination: sort finishes naturally or user taps "Done for now"
- Elo ratings assigned from final rank after sort completes, preserving sparkline and cross-session history without driving comparisons

Also remove the "~" prefix from the remaining count label in PairwiseView since the count is now exact rather than approximate.

Also includes 9 passing XCUITests covering launch, tab navigation, and the Prioritise tab's list picker state.