### PR TITLE
Remove tab bar; Settings → corner gear, Prioritise → fullScreenCover

### DIFF
--- a/Sources/PairwiseReminders/Views/ContentView.swift
+++ b/Sources/PairwiseReminders/Views/ContentView.swift
@@ -1,34 +1,14 @@
 import SwiftUI
 
-/// Root view. Requests Reminders access, syncs with EventKit, then shows
-/// a tab bar with Home, Prioritise, and Settings.
+/// Root view. Requests Reminders access, syncs with EventKit, then shows HomeView.
 struct ContentView: View {
 
     @EnvironmentObject private var remindersManager: RemindersManager
-    @EnvironmentObject private var session: PairwiseSession
     @Environment(\.modelContext) private var modelContext
 
-    @State private var selectedTab: Int = 0
-
     var body: some View {
-        TabView(selection: $selectedTab) {
-            HomeView()
-                .tabItem { Label("Home", systemImage: "house") }
-                .tag(0)
-
-            PrioritiseTab()
-                .tabItem { Label("Prioritise", systemImage: "arrow.up.arrow.down") }
-                .tag(1)
-
-            SettingsView()
-                .tabItem { Label("Settings", systemImage: "gear") }
-                .tag(2)
-        }
-        // When a list sets pendingListIDs, switch to the Prioritise tab automatically.
-        .onChange(of: session.pendingListIDs) { _, ids in
-            if !ids.isEmpty { selectedTab = 1 }
-        }
-        .task { await bootstrap() }
+        HomeView()
+            .task { await bootstrap() }
     }
 
     private func bootstrap() async {
@@ -41,26 +21,5 @@ struct ContentView: View {
             break
         }
         await remindersManager.syncWithEventKit(context: modelContext)
-    }
-}
-
-// MARK: - Prioritise Tab
-
-/// Houses the full seeding → comparison → summary session flow.
-private struct PrioritiseTab: View {
-
-    @EnvironmentObject private var session: PairwiseSession
-    @EnvironmentObject private var eloEngine: EloEngine
-    @Environment(\.modelContext) private var modelContext
-
-    var body: some View {
-        NavigationStack {
-            switch session.phase {
-            case .idle:      ListPickerView()
-            case .seeding:   FilteringView()
-            case .comparing: PairwiseView()
-            case .done:      ResultsView()
-            }
-        }
     }
 }

--- a/Sources/PairwiseReminders/Views/HomeView.swift
+++ b/Sources/PairwiseReminders/Views/HomeView.swift
@@ -2,7 +2,8 @@ import SwiftUI
 import SwiftData
 import EventKit
 
-/// Home tab: shows all imported Reminders lists with ranking progress and staleness.
+/// Root view. Shows all imported Reminders lists with ranking progress and staleness.
+/// Houses the Settings sheet (gear icon) and Prioritise flow (fullScreenCover).
 struct HomeView: View {
 
     @EnvironmentObject private var remindersManager: RemindersManager
@@ -13,6 +14,8 @@ struct HomeView: View {
     @Query private var allRecords: [RankedItemRecord]
 
     @State private var selectedList: EKCalendar?
+    @State private var showPrioritise = false
+    @State private var showSettings = false
 
     var body: some View {
         NavigationStack {
@@ -27,7 +30,40 @@ struct HomeView: View {
             .navigationDestination(item: $selectedList) { calendar in
                 ListDetailView(calendar: calendar)
             }
-            .task { await remindersManager.syncWithEventKit(context: modelContext) }
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    HStack(spacing: 4) {
+                        Button {
+                            showPrioritise = true
+                        } label: {
+                            Image(systemName: "arrow.up.arrow.down.circle")
+                                .font(.title3)
+                        }
+                        Button {
+                            showSettings = true
+                        } label: {
+                            Image(systemName: "gear")
+                                .font(.title3)
+                        }
+                    }
+                }
+            }
+            .fullScreenCover(isPresented: $showPrioritise) {
+                PrioritiseFlow()
+            }
+            .sheet(isPresented: $showSettings) {
+                SettingsView()
+            }
+            // Pre-select lists forwarded from ListDetailView and open the flow.
+            .onChange(of: session.pendingListIDs) { _, ids in
+                if !ids.isEmpty, !showPrioritise {
+                    showPrioritise = true
+                }
+            }
+            // Dismiss the Prioritise flow when the session resets to idle.
+            .onChange(of: session.phase) { _, phase in
+                if phase == .idle { showPrioritise = false }
+            }
         }
     }
 
@@ -72,6 +108,26 @@ struct HomeView: View {
 
     private func records(for calendar: EKCalendar) -> [RankedItemRecord] {
         allRecords.filter { $0.listCalendarIdentifier == calendar.calendarIdentifier }
+    }
+}
+
+// MARK: - Prioritise Flow
+
+/// Full-screen session flow: list selection → AI seeding → pairwise comparison → results.
+/// Presented as a fullScreenCover from HomeView to avoid gesture conflicts with PairwiseView.
+private struct PrioritiseFlow: View {
+
+    @EnvironmentObject private var session: PairwiseSession
+
+    var body: some View {
+        NavigationStack {
+            switch session.phase {
+            case .idle:      ListPickerView()
+            case .seeding:   FilteringView()
+            case .comparing: PairwiseView()
+            case .done:      ResultsView()
+            }
+        }
     }
 }
 
@@ -141,4 +197,3 @@ private struct ListRowView: View {
         }
     }
 }
-

--- a/Sources/PairwiseReminders/Views/ListPickerView.swift
+++ b/Sources/PairwiseReminders/Views/ListPickerView.swift
@@ -11,12 +11,19 @@ struct ListPickerView: View {
     @EnvironmentObject private var eloEngine: EloEngine
     @Environment(\.modelContext) private var modelContext
 
+    @Environment(\.dismiss) private var dismiss
+
     @State private var selectedListIDs: Set<String> = []
     @State private var errorMessage: String?
 
     var body: some View {
         content
             .navigationTitle("Choose Lists")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
             .task { await remindersManager.fetchLists() }
             .onAppear {
                 // Pre-select any lists forwarded from HomeView / ListDetailView.


### PR DESCRIPTION
- ContentView: drop TabView entirely; just renders HomeView + bootstrap
- HomeView: gear icon (top-right) opens SettingsView as a sheet; arrow.up.arrow.down icon opens the Prioritise session flow as a fullScreenCover (avoids gesture conflict with PairwiseView swipes)
- ListPickerView: add Cancel button so user can exit the cover before starting a session
- pendingListIDs (set by ListDetailView "Add to Prioritise") now opens the cover instead of switching a tab
- session.phase == .idle dismisses the cover automatically after "Done"