### PR TITLE
Fix text jitter, AI seeding banner, results layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,7 @@ The API key is entered in `SettingsView` (gear icon in HomeView). No onboarding 
 - After pushing a completed batch of work to a feature branch, **always create a GitHub PR** using `mcp__github__create_pull_request` — unless one already exists for that branch, or the user explicitly asks not to.
 - Check for an existing open PR with `mcp__github__list_pull_requests` before creating a new one.
 - PR title should be concise (≤70 chars). Body should bullet the changes and include a test plan checklist.
+- **Every user request that is not implemented immediately must have a GitHub issue.** Before ending a working session, check the conversation for any unresolved requests and create issues for them. Title: concise description. Body: the user's words + relevant context.
 
 ---
 

--- a/Sources/PairwiseReminders/Views/FilteringView.swift
+++ b/Sources/PairwiseReminders/Views/FilteringView.swift
@@ -7,9 +7,7 @@ struct FilteringView: View {
 
     @EnvironmentObject private var session: PairwiseSession
 
-    @State private var statusLine = "Getting ready…"
-    @State private var dotCount = 0
-    private let dotTimer = Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()
+    @State private var statusLine = "Fetching reminders…"
 
     var body: some View {
         VStack(spacing: 36) {
@@ -43,26 +41,19 @@ struct FilteringView: View {
             Spacer()
         }
         .padding()
-        .onReceive(dotTimer) { _ in
-            updateStatus()
-        }
-        .onChange(of: session.phase) { _, newPhase in
-            // PairwiseSession advances phase to .comparing when done; nothing else needed here.
-            _ = newPhase
+        .onAppear { updateStatus(count: session.sessionItems.count) }
+        .onChange(of: session.sessionItems.count) { _, count in
+            updateStatus(count: count)
         }
     }
 
-    private func updateStatus() {
-        let count = session.sessionItems.count
-        let dots = String(repeating: ".", count: (dotCount % 3) + 1)
-        dotCount += 1
-
+    private func updateStatus(count: Int) {
         if count == 0 {
-            statusLine = "Fetching reminders\(dots)"
+            statusLine = "Fetching reminders…"
         } else if session.aiPreference == .none {
-            statusLine = "Preparing \(count) item\(count == 1 ? "" : "s") for comparison\(dots)"
+            statusLine = "Preparing \(count) item\(count == 1 ? "" : "s")…"
         } else {
-            statusLine = "AI is ranking \(count) item\(count == 1 ? "" : "s")\(dots)"
+            statusLine = "AI is ranking \(count) item\(count == 1 ? "" : "s")…"
         }
     }
 }

--- a/Sources/PairwiseReminders/Views/PairwiseView.swift
+++ b/Sources/PairwiseReminders/Views/PairwiseView.swift
@@ -104,7 +104,7 @@ struct PairwiseView: View {
             .tint(.blue)
             .padding(.horizontal)
 
-            if session.seedingFailed {
+            if session.seedingFailed && session.aiPreference != .none {
                 Text("AI seeding unavailable — using default ratings")
                     .font(.caption2)
                     .foregroundStyle(.secondary)

--- a/Sources/PairwiseReminders/Views/ResultsView.swift
+++ b/Sources/PairwiseReminders/Views/ResultsView.swift
@@ -17,7 +17,9 @@ struct ResultsView: View {
     var body: some View {
         VStack(spacing: 0) {
             header
+                .fixedSize(horizontal: false, vertical: true)
             rankedList
+                .frame(maxHeight: .infinity)
             bottomBar
         }
         .navigationTitle("Session Results")
@@ -47,8 +49,8 @@ struct ResultsView: View {
 
     private var header: some View {
         VStack(spacing: 6) {
-            if session.seedingFailed {
-                Label("AI seeding was unavailable", systemImage: "info.circle")
+            if session.seedingFailed && session.aiPreference != .none {
+                Label("AI seeding was unavailable — rankings may be less accurate", systemImage: "info.circle")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .padding(.top, 8)


### PR DESCRIPTION
## Summary

- **FilteringView**: Replaced the 3-dot animation (1 dot → 2 dots → 3 dots) with a static `…` that doesn't change the text width, eliminating the centering jitter when the text is center-aligned. Status updates once when item count changes, not on a timer.
- **PairwiseView + ResultsView**: "AI seeding unavailable" banner now only appears when AI was expected but unavailable — not when the user deliberately set `aiPreference = .none`. Fixes misleading "unavailable" message when AI is simply disabled.
- **ResultsView**: Added `maxHeight: .infinity` to the ranked list and `fixedSize` to the header banner, so the `List` fills available space and the banner appearing/disappearing doesn't break layout or scrolling.
- **CLAUDE.md**: Added workflow rule — every unimplemented user request must become a GitHub issue before ending a session.

## Test plan

- [ ] Start a session with `aiPreference = .none` → no "AI seeding unavailable" banner appears in PairwiseView or ResultsView
- [ ] Start a session with a bad API key (AI expected but fails) → banner does appear
- [ ] Watch FilteringView during seeding — status text stays still, no width jitter
- [ ] ResultsView scrolls cleanly with and without the seeding banner