### PR TITLE
Startup speed, pairwise UX, None label fix

### DIFF
--- a/Sources/PairwiseReminders/Services/RemindersManager.swift
+++ b/Sources/PairwiseReminders/Services/RemindersManager.swift
@@ -18,6 +18,11 @@ final class RemindersManager: ObservableObject {
 
     init() {
         authorizationStatus = EKEventStore.authorizationStatus(for: .reminder)
+        // Load lists synchronously if access is already granted so HomeView shows
+        // immediately on launch without waiting for any async work.
+        if authorizationStatus == .fullAccess {
+            lists = store.calendars(for: .reminder)
+        }
     }
 
     // MARK: - Access

--- a/Sources/PairwiseReminders/Views/ContentView.swift
+++ b/Sources/PairwiseReminders/Views/ContentView.swift
@@ -12,14 +12,11 @@ struct ContentView: View {
     }
 
     private func bootstrap() async {
-        switch remindersManager.authorizationStatus {
-        case .notDetermined:
+        if remindersManager.authorizationStatus == .notDetermined {
             _ = await remindersManager.requestAccess()
-        case .fullAccess:
-            await remindersManager.fetchLists()
-        default:
-            break
         }
+        // syncWithEventKit calls fetchLists() internally and updates SwiftData.
+        // Lists may already be populated from init() if access was pre-granted.
         await remindersManager.syncWithEventKit(context: modelContext)
     }
 }

--- a/Sources/PairwiseReminders/Views/PairwiseView.swift
+++ b/Sources/PairwiseReminders/Views/PairwiseView.swift
@@ -160,7 +160,7 @@ struct PairwiseView: View {
                     .foregroundStyle(.tertiary)
                 Spacer()
             }
-            .padding(.vertical, 10)
+            .padding(.vertical, 8)
 
             // Large bottom card — swipe right to pick it, swipe left to pick top card
             swipeCard(item: bottomItem, versus: topItem)
@@ -170,19 +170,27 @@ struct PairwiseView: View {
             swipeHints
                 .padding(.top, 10)
 
-            HStack(spacing: 20) {
-                Button("About equal") { engine.equal() }
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
+            HStack(spacing: 12) {
+                Button {
+                    engine.equal()
+                } label: {
+                    Label("Equal", systemImage: "equal")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .tint(.secondary)
 
-                Text("·")
-                    .foregroundStyle(.tertiary)
-                    .font(.subheadline)
-
-                Button("Skip") { engine.skip() }
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                Button {
+                    engine.skip()
+                } label: {
+                    Label("Skip", systemImage: "forward.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .tint(.secondary)
             }
+            .controlSize(.regular)
+            .padding(.horizontal)
             .padding(.top, 12)
 
             Spacer(minLength: 20)
@@ -219,7 +227,7 @@ struct PairwiseView: View {
     @ViewBuilder
     private func swipeOverlay(normalized: CGFloat) -> some View {
         let magnitude = abs(normalized)
-        if magnitude > 0.25 {
+        if magnitude > 0.12 {
             let pickingThis = normalized > 0
             RoundedRectangle(cornerRadius: 18)
                 .fill((pickingThis ? Color.green : Color.blue).opacity(magnitude * 0.3))
@@ -241,17 +249,20 @@ struct PairwiseView: View {
         HStack {
             HStack(spacing: 4) {
                 Image(systemName: "arrow.left")
-                Text("top one")
+                    .font(.caption.bold())
+                Text("Pick top card")
+                    .font(.caption)
             }
             Spacer()
             HStack(spacing: 4) {
-                Text("this one")
+                Text("Pick this card")
+                    .font(.caption)
                 Image(systemName: "arrow.right")
+                    .font(.caption.bold())
             }
         }
-        .font(.caption)
-        .foregroundStyle(.tertiary)
-        .padding(.horizontal, 28)
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 24)
     }
 
     // MARK: - Compact Top Card
@@ -268,14 +279,23 @@ struct PairwiseView: View {
                     .foregroundStyle(.secondary)
             }
             Spacer()
-            Image(systemName: "hand.tap")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
+            VStack(alignment: .trailing, spacing: 3) {
+                Image(systemName: "cursorarrow.click")
+                    .font(.subheadline)
+                    .foregroundStyle(.blue.opacity(0.6))
+                Text("Tap to pick")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
         }
         .padding(14)
         .background(
             RoundedRectangle(cornerRadius: 14)
                 .fill(Color(.secondarySystemBackground))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14)
+                        .stroke(Color.blue.opacity(0.18), lineWidth: 1)
+                )
         )
     }
 }

--- a/Sources/PairwiseReminders/Views/ResultsView.swift
+++ b/Sources/PairwiseReminders/Views/ResultsView.swift
@@ -375,19 +375,22 @@ struct ApplySheet: View {
                             in: 0...max(0, itemCount - options.highCount - options.lowCount))
                     Stepper("Low: \(options.lowCount)", value: $options.lowCount,
                             in: 0...max(0, itemCount - options.highCount - options.mediumCount))
+                    let noneCount = max(0, itemCount - options.highCount - options.mediumCount - options.lowCount)
+                    HStack {
+                        Text("None (remainder)")
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text("\(noneCount)")
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                    }
                 }
             }
         } header: {
             Text("Priorities")
         } footer: {
-            if options.applyPriorities {
-                if options.priorityMode == .topN {
-                    Text("Items 1–\(options.urgentCount) → High. All others → None.")
-                } else {
-                    let h = options.highCount, m = options.mediumCount, l = options.lowCount
-                    let none = max(0, itemCount - h - m - l)
-                    Text("High: \(h)  Medium: \(m)  Low: \(l)  None: \(none)")
-                }
+            if options.applyPriorities && options.priorityMode == .topN {
+                Text("Items 1–\(options.urgentCount) → High. All others → None.")
             }
         }
     }


### PR DESCRIPTION
## Summary

Closes #65, #67, #72.

### Startup speed (#65)
`RemindersManager.init()` now loads calendars synchronously when Reminders access is already granted. For returning users the home screen appears immediately on launch rather than after an async round-trip. The `bootstrap()` sequence is simplified — no duplicate `fetchLists()` call before `syncWithEventKit`.

### Pairwise screen UX (#67)
- **"About equal" and "Skip"** are now `.bordered` buttons with SF Symbol icons (`equal`, `forward.fill`), replacing the invisible text-only links
- **Compact top card** gains a subtle blue outline stroke and a "Tap to pick" label with a cursor icon — makes the affordance unmistakable
- **Swipe hints** upgraded from `.tertiary` to `.secondary` colour with bold arrows: "Pick top card ←" and "→ Pick this card"  
- **Swipe overlay** now appears at 12% drag instead of 25%, so the colour feedback kicks in sooner and reinforces the gesture earlier

### Apply sheet — None tier label (#72)
In Distribute mode the priorities section now shows a read-only **"None (remainder): X"** row right after the Low stepper, visible inline alongside the other tier counts. The footer is removed in this mode since the row makes it redundant.

## Test plan

- [ ] Build succeeds
- [ ] Launch app with Reminders access already granted → home screen shows lists immediately (no blank flash)
- [ ] Pairwise view: "About equal" and "Skip" look like bordered buttons
- [ ] Top card has blue outline and "Tap to pick" label; tapping picks it
- [ ] Swipe hints are `.secondary` grey and readable
- [ ] Dragging the bottom card a small amount already shows the green/blue overlay
- [ ] Apply sheet → Priorities → Distribute mode: "None (remainder): X" row shows and updates as steppers change