### PR TITLE
History view: compact what-beat-what log

### DIFF
--- a/PairwiseReminders.xcodeproj/project.pbxproj
+++ b/PairwiseReminders.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		AA0000000000000000000044 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000000000000000000043 /* HomeView.swift */; };
 		AA0000000000000000000046 /* ListDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000000000000000000045 /* ListDetailView.swift */; };
 		AA0000000000000000000048 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000000000000000000047 /* SettingsView.swift */; };
+		AA000000000000000000004A /* ComparisonRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000000000000000000049 /* ComparisonRecord.swift */; };
+		AA000000000000000000004C /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000004B /* HistoryView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -74,6 +76,8 @@
 		AA0000000000000000000043 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		AA0000000000000000000045 /* ListDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListDetailView.swift; sourceTree = "<group>"; };
 		AA0000000000000000000047 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		AA0000000000000000000049 /* ComparisonRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComparisonRecord.swift; sourceTree = "<group>"; };
+		AA000000000000000000004B /* HistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -156,6 +160,7 @@
 				AA0000000000000000000019 /* PairwiseSession.swift */,
 				AA0000000000000000000039 /* RankedItemRecord.swift */,
 				AA000000000000000000003B /* ListConfig.swift */,
+				AA0000000000000000000049 /* ComparisonRecord.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -191,6 +196,7 @@
 				AA0000000000000000000043 /* HomeView.swift */,
 				AA0000000000000000000045 /* ListDetailView.swift */,
 				AA0000000000000000000047 /* SettingsView.swift */,
+				AA000000000000000000004B /* HistoryView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -385,6 +391,8 @@
 				AA0000000000000000000044 /* HomeView.swift in Sources */,
 				AA0000000000000000000046 /* ListDetailView.swift in Sources */,
 				AA0000000000000000000048 /* SettingsView.swift in Sources */,
+				AA000000000000000000004A /* ComparisonRecord.swift in Sources */,
+				AA000000000000000000004C /* HistoryView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/PairwiseReminders/Engine/EloEngine.swift
+++ b/Sources/PairwiseReminders/Engine/EloEngine.swift
@@ -54,6 +54,9 @@ final class EloEngine: ObservableObject {
     /// deltas can be re-applied correctly after an undo resets items to startItems.
     private var decisionHistory: [(pairKey: String, winnerID: String, loserID: String)] = []
 
+    /// UUID identifying all decisions from this session. Generated fresh each `start()`.
+    private var sessionID: String = ""
+
     // MARK: - Public Interface
 
     /// Starts the merge sort. Items are pre-ordered by their Elo rating (AI seed order)
@@ -61,6 +64,7 @@ final class EloEngine: ObservableObject {
     func start(with items: [ReminderItem]) {
         guard !isStarted else { return }
         comparisonCount = 0
+        sessionID = UUID().uuidString
         self.items = items.sorted { $0.eloRating > $1.eloRating }
         startItems = self.items
         totalComparisons = worstCaseComparisons(self.items.count)
@@ -140,6 +144,7 @@ final class EloEngine: ObservableObject {
         totalComparisons = 0
         decisionHistory = []
         canUndo = false
+        sessionID = ""
     }
 
     // MARK: - Private Helpers
@@ -265,6 +270,25 @@ final class EloEngine: ObservableObject {
                 record.lastComparedAt = now
             }
         }
+
+        // Persist comparison decisions for the history log.
+        if !decisionHistory.isEmpty && !sessionID.isEmpty {
+            let titleByID = Dictionary(items.map { ($0.id, $0.title) },
+                                      uniquingKeysWith: { first, _ in first })
+            for (index, decision) in decisionHistory.enumerated() {
+                let record = ComparisonRecord(
+                    sessionID: sessionID,
+                    sessionDate: now,
+                    order: index,
+                    winnerID: decision.winnerID,
+                    winnerTitle: titleByID[decision.winnerID] ?? decision.winnerID,
+                    loserID: decision.loserID,
+                    loserTitle: titleByID[decision.loserID] ?? decision.loserID
+                )
+                context.insert(record)
+            }
+        }
+
         try? context.save()
     }
 }

--- a/Sources/PairwiseReminders/Models/ComparisonRecord.swift
+++ b/Sources/PairwiseReminders/Models/ComparisonRecord.swift
@@ -1,0 +1,47 @@
+import Foundation
+import SwiftData
+
+/// Persists a single pairwise comparison decision.
+///
+/// All decisions from one Prioritise session share the same `sessionID`.
+/// Written in batch when the session finishes (converged or "Done for now").
+@Model
+final class ComparisonRecord {
+
+    /// Groups all decisions from the same session. Generated once per `EloEngine.start()`.
+    var sessionID: String
+
+    /// When the session ended — used as the section header in HistoryView.
+    var sessionDate: Date
+
+    /// Position of this comparison within the session (0-based). Preserves decision order.
+    var order: Int
+
+    // MARK: - Winner
+
+    var winnerID: String
+    var winnerTitle: String
+
+    // MARK: - Loser
+
+    var loserID: String
+    var loserTitle: String
+
+    init(
+        sessionID: String,
+        sessionDate: Date,
+        order: Int,
+        winnerID: String,
+        winnerTitle: String,
+        loserID: String,
+        loserTitle: String
+    ) {
+        self.sessionID   = sessionID
+        self.sessionDate = sessionDate
+        self.order       = order
+        self.winnerID    = winnerID
+        self.winnerTitle = winnerTitle
+        self.loserID     = loserID
+        self.loserTitle  = loserTitle
+    }
+}

--- a/Sources/PairwiseReminders/Services/PersistenceController.swift
+++ b/Sources/PairwiseReminders/Services/PersistenceController.swift
@@ -3,9 +3,10 @@ import SwiftData
 
 /// Owns the SwiftData ModelContainer for the app. Access via `PersistenceController.shared`.
 ///
-/// The container holds two models:
+/// The container holds three models:
 /// - `RankedItemRecord`: Elo rating metadata per reminder.
 /// - `ListConfig`: Per-list import and write-back configuration.
+/// - `ComparisonRecord`: Individual pairwise comparison decisions for the history log.
 @MainActor
 final class PersistenceController {
 
@@ -14,7 +15,7 @@ final class PersistenceController {
     let container: ModelContainer
 
     private init() {
-        let schema = Schema([RankedItemRecord.self, ListConfig.self])
+        let schema = Schema([RankedItemRecord.self, ListConfig.self, ComparisonRecord.self])
         let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
         do {
             container = try ModelContainer(for: schema, configurations: config)

--- a/Sources/PairwiseReminders/Views/HistoryView.swift
+++ b/Sources/PairwiseReminders/Views/HistoryView.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+import SwiftData
+
+/// Compact log of every pairwise comparison decision, grouped by session.
+struct HistoryView: View {
+
+    @Query(sort: \ComparisonRecord.sessionDate, order: .reverse) private var records: [ComparisonRecord]
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if records.isEmpty {
+                    emptyState
+                } else {
+                    sessionList
+                }
+            }
+            .navigationTitle("Comparison History")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+
+    // MARK: - Session List
+
+    private var sessionList: some View {
+        // Group records by sessionID, preserving descending session date order.
+        let grouped = groupedSessions()
+        return List {
+            ForEach(grouped, id: \.id) { session in
+                Section {
+                    ForEach(Array(session.decisions.enumerated()), id: \.offset) { _, decision in
+                        DecisionRow(winner: decision.winnerTitle, loser: decision.loserTitle)
+                    }
+                } header: {
+                    SessionHeader(date: session.date, count: session.decisions.count)
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "clock.arrow.trianglehead.counterclockwise.rotate.90")
+                .font(.system(size: 44))
+                .foregroundStyle(.secondary)
+            Text("No history yet")
+                .font(.title3.bold())
+            Text("Comparison decisions are saved here after each Prioritise session.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 40)
+        }
+    }
+
+    // MARK: - Grouping
+
+    private struct SessionGroup: Identifiable {
+        let id: String          // sessionID
+        let date: Date
+        let decisions: [ComparisonRecord]
+    }
+
+    private func groupedSessions() -> [SessionGroup] {
+        var seen: [String: SessionGroup] = [:]
+        var order: [String] = []
+
+        for record in records {
+            if seen[record.sessionID] == nil {
+                seen[record.sessionID] = SessionGroup(id: record.sessionID,
+                                                      date: record.sessionDate,
+                                                      decisions: [])
+                order.append(record.sessionID)
+            }
+        }
+
+        // Collect decisions per session in ascending order (the stored `order` field).
+        var buckets: [String: [ComparisonRecord]] = [:]
+        for record in records {
+            buckets[record.sessionID, default: []].append(record)
+        }
+        for key in buckets.keys {
+            buckets[key]?.sort { $0.order < $1.order }
+        }
+
+        return order.compactMap { id in
+            guard let group = seen[id], let decisions = buckets[id] else { return nil }
+            return SessionGroup(id: id, date: group.date, decisions: decisions)
+        }
+    }
+}
+
+// MARK: - Sub-views
+
+private struct SessionHeader: View {
+    let date: Date
+    let count: Int
+
+    var body: some View {
+        HStack {
+            Text(date, style: .date)
+            Text("·")
+                .foregroundStyle(.tertiary)
+            Text(date, style: .time)
+            Spacer()
+            Text("\(count) comparison\(count == 1 ? "" : "s")")
+                .foregroundStyle(.secondary)
+        }
+        .font(.caption)
+    }
+}
+
+private struct DecisionRow: View {
+    let winner: String
+    let loser: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "crown.fill")
+                .font(.caption2)
+                .foregroundStyle(.orange)
+                .padding(.top, 2)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(winner)
+                    .font(.subheadline)
+                    .foregroundStyle(.primary)
+                HStack(spacing: 4) {
+                    Image(systemName: "arrow.down")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                    Text(loser)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}

--- a/Sources/PairwiseReminders/Views/ResultsView.swift
+++ b/Sources/PairwiseReminders/Views/ResultsView.swift
@@ -10,6 +10,7 @@ struct ResultsView: View {
     @EnvironmentObject private var eloEngine: EloEngine
 
     @State private var showApplySheet = false
+    @State private var showHistory = false
     @State private var applyError: String?
     @State private var applied = false
     @State private var editingItem: ReminderItem?
@@ -25,6 +26,21 @@ struct ResultsView: View {
         .navigationTitle("Session Results")
         .navigationBarTitleDisplayMode(.large)
         .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    showHistory = true
+                } label: {
+                    Image(systemName: "clock.arrow.trianglehead.counterclockwise.rotate.90")
+                }
+                .accessibilityLabel("Comparison history")
+            }
+        }
+        .sheet(isPresented: $showHistory) {
+            HistoryView()
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
+        }
         .sheet(isPresented: $showApplySheet) {
             ApplySheet(items: session.rankedItems) { options in
                 applyOptions(options)


### PR DESCRIPTION
## Summary

- New `ComparisonRecord` SwiftData model persists every pairwise decision (winner title, loser title, session ID, order index)
- `EloEngine` generates a `sessionID` UUID per session in `start()`; `persist()` now batch-writes `ComparisonRecord` entries alongside existing Elo updates — so history is saved whether the session converges or the user bails out
- `PersistenceController` registers `ComparisonRecord` in the schema
- New `HistoryView`: sessions grouped by date (newest first), compact rows showing a crown icon + "winner → loser" layout; graceful empty state for first use
- `ResultsView` toolbar gets a clock button that opens `HistoryView` as a sheet

Closes #68.

## Test plan

- [ ] Complete a short Prioritise session (2–3 comparisons), tap Done → open history clock button → decisions appear grouped under today's date
- [ ] Bail out mid-session with "Done for now" → decisions made so far should appear in history
- [ ] Multiple sessions → each appears as a separate section, newest first
- [ ] Undo a comparison → undone decision does not appear in history (history only reflects final decisions in `decisionHistory` at `finish()` time)
- [ ] Empty state shown when no sessions have been completed yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)