### PR TITLE
HomeView: standard iOS selection mode

### DIFF
--- a/Sources/PairwiseReminders/Views/HomeView.swift
+++ b/Sources/PairwiseReminders/Views/HomeView.swift
@@ -18,6 +18,7 @@ struct HomeView: View {
     @State private var showPrioritise = false
     @State private var showSettings = false
     @State private var showPrioritiseOptions = false
+    @State private var showHistory = false
 
     @State private var expandedListIDs: Set<String> = []
     @State private var selectedListIDs: Set<String> = []
@@ -60,8 +61,13 @@ struct HomeView: View {
                     .font(.subheadline)
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Button { showSettings = true } label: {
-                        Image(systemName: "gear")
+                    HStack(spacing: 16) {
+                        Button { showHistory = true } label: {
+                            Image(systemName: "clock.arrow.trianglehead.counterclockwise.rotate.90")
+                        }
+                        Button { showSettings = true } label: {
+                            Image(systemName: "gear")
+                        }
                     }
                 }
             }
@@ -70,6 +76,9 @@ struct HomeView: View {
             }
             .sheet(isPresented: $showSettings) {
                 SettingsView()
+            }
+            .sheet(isPresented: $showHistory) {
+                HistoryView()
             }
             .sheet(isPresented: $showPrioritiseOptions) {
                 PrioritiseOptionsSheet(listIDs: selectedListIDs) {
@@ -145,25 +154,24 @@ struct HomeView: View {
             let ranked = items.filter { $0.comparisonCount > 0 }
                               .sorted { $0.eloRating > $1.eloRating }
             let unranked = items.filter { $0.comparisonCount == 0 }
-            let total = ranked.count
+            let eloMin = ranked.last?.eloRating ?? 1000
+            let eloMax = ranked.first?.eloRating ?? 1000
 
-            if ranked.isEmpty && unranked.isEmpty {
+            if items.isEmpty {
                 Text("No incomplete reminders")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .listRowBackground(Color.clear)
             } else {
                 ForEach(Array(ranked.enumerated()), id: \.element.id) { index, item in
-                    ExpandedItemRow(item: item, rank: index + 1, total: total)
+                    ExpandedItemRow(item: item, rank: index + 1, eloMin: eloMin, eloMax: eloMax)
                         .contentShape(Rectangle())
                         .onTapGesture { selectedList = calendar }
                 }
-                if !unranked.isEmpty {
-                    Text("\(unranked.count) unranked item\(unranked.count == 1 ? "" : "s")")
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .listRowBackground(Color.clear)
+                ForEach(unranked, id: \.id) { item in
+                    ExpandedItemRow(item: item, rank: nil, eloMin: eloMin, eloMax: eloMax)
+                        .contentShape(Rectangle())
+                        .onTapGesture { selectedList = calendar }
                 }
             }
         }
@@ -379,13 +387,10 @@ private struct CollapsedListHeader: View {
     private var rankedRecords: [RankedItemRecord] {
         records.filter { $0.comparisonCount > 0 }.sorted { $0.eloRating > $1.eloRating }
     }
-    private var rankedCount: Int { rankedRecords.count }
-    private var unrankedCount: Int { records.filter { $0.comparisonCount == 0 }.count }
 
     var body: some View {
         HStack(spacing: 10) {
-            // List colour + name
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: 6) {
                 HStack(spacing: 8) {
                     Circle()
                         .fill(Color(cgColor: calendar.cgColor))
@@ -394,29 +399,7 @@ private struct CollapsedListHeader: View {
                         .font(.body.bold())
                         .foregroundStyle(.primary)
                 }
-
-                if rankedCount > 0 {
-                    HStack(spacing: 8) {
-                        Text("\(rankedCount) ranked")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        if unrankedCount > 0 {
-                            Text("· \(unrankedCount) unranked")
-                                .font(.caption)
-                                .foregroundStyle(.tertiary)
-                        }
-                    }
-                    eloSparkline
-                    tierSummary
-                } else if unrankedCount > 0 {
-                    Text("\(unrankedCount) item\(unrankedCount == 1 ? "" : "s") · not yet ranked")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                } else {
-                    Text("No incomplete reminders")
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                }
+                eloSparkline
             }
 
             Spacer()
@@ -449,93 +432,65 @@ private struct CollapsedListHeader: View {
             .frame(height: 16, alignment: .bottom)
         }
     }
-
-    @ViewBuilder
-    private var tierSummary: some View {
-        let n = rankedCount
-        if n > 0 {
-            let q = max(n / 4, 1)
-            let h = q, m = q, l = q
-            let none = n - h - m - l
-            HStack(spacing: 10) {
-                tierBadge("H", count: h, color: .red)
-                tierBadge("M", count: m, color: .orange)
-                tierBadge("L", count: l, color: .yellow)
-                if none > 0 {
-                    tierBadge("–", count: none, color: Color(.secondaryLabel))
-                }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func tierBadge(_ label: String, count: Int, color: Color) -> some View {
-        HStack(spacing: 2) {
-            Text(label)
-                .font(.caption2.bold())
-                .foregroundStyle(color)
-            Text("\(count)")
-                .font(.caption2)
-                .foregroundStyle(.secondary)
-        }
-    }
 }
 
 // MARK: - Expanded Item Row
 
 private struct ExpandedItemRow: View {
     let item: ReminderItem
-    let rank: Int
-    let total: Int
+    /// 1-based rank for items that have been compared; nil for unranked items.
+    let rank: Int?
+    let eloMin: Double
+    let eloMax: Double
 
-    private var priorityLabel: String {
-        let q = max(total / 4, 1)
-        let r = rank - 1  // 0-based
-        if r < q         { return "High" }
-        if r < q * 2     { return "Medium" }
-        if r < q * 3     { return "Low" }
-        return "None"
+    private var eloStrength: Double {
+        guard rank != nil, eloMax > eloMin else { return 0 }
+        return max(0, min(1, (item.eloRating - eloMin) / (eloMax - eloMin)))
     }
 
-    private var priorityColor: Color {
-        let q = max(total / 4, 1)
-        let r = rank - 1
-        if r < q         { return .red }
-        if r < q * 2     { return .orange }
-        if r < q * 3     { return .yellow }
-        return Color(.secondaryLabel)
+    private var barTint: Color {
+        if eloStrength > 0.66 { return .blue }
+        if eloStrength > 0.33 { return .indigo }
+        return Color(.systemGray3)
     }
 
     var body: some View {
         HStack(spacing: 10) {
-            ZStack {
+            // Rank badge for compared items; plain circle for unranked (matches Reminders.app)
+            if let r = rank {
+                ZStack {
+                    Circle()
+                        .fill(badgeColor(r))
+                        .frame(width: 28, height: 28)
+                    Text("\(r)")
+                        .font(.system(.caption, design: .rounded).bold())
+                        .foregroundStyle(.white)
+                }
+            } else {
                 Circle()
-                    .fill(badgeColor)
-                    .frame(width: 28, height: 28)
-                Text("\(rank)")
-                    .font(.system(.caption, design: .rounded).bold())
-                    .foregroundStyle(.white)
+                    .strokeBorder(Color(.tertiaryLabel), lineWidth: 1.5)
+                    .frame(width: 26, height: 26)
             }
 
-            Text(item.title)
-                .font(.subheadline)
-                .lineLimit(1)
-                .foregroundStyle(.primary)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(item.title)
+                    .font(.subheadline)
+                    .lineLimit(1)
+                    .foregroundStyle(.primary)
 
-            Spacer()
-
-            Text(priorityLabel)
-                .font(.caption2.bold())
-                .padding(.horizontal, 6)
-                .padding(.vertical, 2)
-                .background(priorityColor.opacity(0.15))
-                .foregroundStyle(priorityColor)
-                .clipShape(RoundedRectangle(cornerRadius: 4))
+                // Continuous Elo strength bar — only for ranked items
+                if rank != nil {
+                    ProgressView(value: eloStrength)
+                        .tint(barTint)
+                        .frame(height: 3)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(.vertical, 2)
     }
 
-    private var badgeColor: Color {
+    private func badgeColor(_ rank: Int) -> Color {
         switch rank {
         case 1: return .blue
         case 2: return .indigo

--- a/Sources/PairwiseReminders/Views/HomeView.swift
+++ b/Sources/PairwiseReminders/Views/HomeView.swift
@@ -22,6 +22,7 @@ struct HomeView: View {
 
     @State private var expandedListIDs: Set<String> = []
     @State private var selectedListIDs: Set<String> = []
+    @State private var isSelecting: Bool = false
     @State private var itemsByList: [String: [ReminderItem]] = [:]
     @State private var loadingListIDs: Set<String> = []
 
@@ -49,25 +50,42 @@ struct HomeView: View {
             }
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
-                    Button(allExpanded ? "Collapse All" : "Expand All") {
-                        if allExpanded {
-                            expandedListIDs = []
-                        } else {
-                            let ids = Set(remindersManager.lists.map(\.calendarIdentifier))
-                            expandedListIDs = ids
-                            ids.forEach { loadItemsIfNeeded(for: $0) }
+                    if isSelecting {
+                        Button("Cancel") {
+                            isSelecting = false
+                            selectedListIDs = []
                         }
+                        .font(.subheadline)
+                    } else {
+                        Button(allExpanded ? "Collapse All" : "Expand All") {
+                            if allExpanded {
+                                expandedListIDs = []
+                            } else {
+                                let ids = Set(remindersManager.lists.map(\.calendarIdentifier))
+                                expandedListIDs = ids
+                                ids.forEach { loadItemsIfNeeded(for: $0) }
+                            }
+                        }
+                        .font(.subheadline)
                     }
-                    .font(.subheadline)
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     HStack(spacing: 16) {
-                        Button { showHistory = true } label: {
-                            Image(systemName: "clock.arrow.trianglehead.counterclockwise.rotate.90")
+                        if isSelecting {
+                            EmptyView()
+                        } else {
+                            Button { showHistory = true } label: {
+                                Image(systemName: "clock.arrow.trianglehead.counterclockwise.rotate.90")
+                            }
+                            Button { showSettings = true } label: {
+                                Image(systemName: "gear")
+                            }
                         }
-                        Button { showSettings = true } label: {
-                            Image(systemName: "gear")
+                        Button(isSelecting ? "Done" : "Select") {
+                            isSelecting.toggle()
+                            if !isSelecting { selectedListIDs = [] }
                         }
+                        .font(.subheadline.weight(isSelecting ? .semibold : .regular))
                     }
                 }
             }
@@ -84,6 +102,7 @@ struct HomeView: View {
                 PrioritiseOptionsSheet(listIDs: selectedListIDs) {
                     showPrioritiseOptions = false
                     showPrioritise = true
+                    isSelecting = false
                     Task {
                         await session.start(
                             listIDs: selectedListIDs,
@@ -131,6 +150,7 @@ struct HomeView: View {
                         calendar: calendar,
                         records: listRecords,
                         isSelected: selectedListIDs.contains(id),
+                        isSelecting: isSelecting,
                         onToggleSelect: { toggleSelect(id) }
                     )
                 }
@@ -182,7 +202,12 @@ struct HomeView: View {
     private var prioritiseButton: some View {
         VStack(spacing: 0) {
             Button {
-                showPrioritiseOptions = true
+                if selectedListIDs.isEmpty {
+                    // Shortcut: tapping the button starts selection mode
+                    isSelecting = true
+                } else {
+                    showPrioritiseOptions = true
+                }
             } label: {
                 Text(prioritiseLabel)
                     .font(.headline)
@@ -194,13 +219,12 @@ struct HomeView: View {
             }
             .padding(.horizontal)
             .padding(.vertical, 12)
-            .disabled(selectedListIDs.isEmpty)
         }
         .background(.regularMaterial)
     }
 
     private var prioritiseLabel: String {
-        if selectedListIDs.isEmpty { return "Select lists to prioritise" }
+        if selectedListIDs.isEmpty { return "Select Lists to Prioritise" }
         let n = selectedListIDs.count
         return "Prioritise \(n == 1 ? "1 List" : "\(n) Lists")"
     }
@@ -382,6 +406,7 @@ private struct CollapsedListHeader: View {
     let calendar: EKCalendar
     let records: [RankedItemRecord]
     let isSelected: Bool
+    let isSelecting: Bool
     let onToggleSelect: () -> Void
 
     private var rankedRecords: [RankedItemRecord] {
@@ -404,12 +429,15 @@ private struct CollapsedListHeader: View {
 
             Spacer()
 
-            // Selection toggle — high priority gesture prevents DisclosureGroup from intercepting
-            Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
-                .foregroundStyle(isSelected ? .blue : Color(.tertiaryLabel))
-                .font(.title3)
-                .animation(.spring(response: 0.25), value: isSelected)
-                .highPriorityGesture(TapGesture().onEnded { onToggleSelect() })
+            // Selection circle — only visible in selection mode (cleaner idle state)
+            if isSelecting {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(isSelected ? .blue : Color(.tertiaryLabel))
+                    .font(.title3)
+                    .animation(.spring(response: 0.25), value: isSelected)
+                    .highPriorityGesture(TapGesture().onEnded { onToggleSelect() })
+                    .transition(.scale.combined(with: .opacity))
+            }
         }
         .padding(.vertical, 4)
     }

--- a/Sources/PairwiseReminders/Views/PairwiseView.swift
+++ b/Sources/PairwiseReminders/Views/PairwiseView.swift
@@ -143,7 +143,7 @@ struct PairwiseView: View {
         let bottomItem = isFlipped ? pair.0 : pair.1
 
         return VStack(spacing: 0) {
-            Spacer()
+            Spacer(minLength: 8)
 
             // Compact top card — tap to pick it, long-press to edit
             Button { engine.choose(winner: topItem) } label: {
@@ -167,31 +167,60 @@ struct PairwiseView: View {
                 .padding(.horizontal)
                 .simultaneousGesture(LongPressGesture().onEnded { _ in editingItem = bottomItem })
 
-            swipeHints
-                .padding(.top, 10)
-
-            HStack(spacing: 12) {
+            // Explicit choice buttons — clear affordance, swipe still works as a shortcut
+            HStack(spacing: 10) {
                 Button {
-                    engine.equal()
+                    engine.choose(winner: topItem)
                 } label: {
-                    Label("Equal", systemImage: "equal")
-                        .frame(maxWidth: .infinity)
+                    HStack(spacing: 6) {
+                        Image(systemName: "arrow.up")
+                            .font(.subheadline.bold())
+                        Text("Top one")
+                            .font(.subheadline.weight(.medium))
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 13)
+                    .background(Color(.secondarySystemBackground))
+                    .foregroundStyle(.primary)
+                    .clipShape(RoundedRectangle(cornerRadius: 13))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 13)
+                            .strokeBorder(Color(.separator), lineWidth: 0.5)
+                    )
                 }
-                .buttonStyle(.bordered)
-                .tint(.secondary)
+                .buttonStyle(.plain)
 
                 Button {
-                    engine.skip()
+                    engine.choose(winner: bottomItem)
                 } label: {
-                    Label("Skip", systemImage: "forward.fill")
-                        .frame(maxWidth: .infinity)
+                    HStack(spacing: 6) {
+                        Image(systemName: "arrow.down")
+                            .font(.subheadline.bold())
+                        Text("This one")
+                            .font(.subheadline.weight(.medium))
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 13)
+                    .background(Color.blue)
+                    .foregroundStyle(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 13))
                 }
-                .buttonStyle(.bordered)
-                .tint(.secondary)
+                .buttonStyle(.plain)
             }
-            .controlSize(.regular)
             .padding(.horizontal)
             .padding(.top, 12)
+
+            // Secondary actions
+            HStack(spacing: 20) {
+                Button("About equal") { engine.equal() }
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Text("·").foregroundStyle(.tertiary)
+                Button("Skip") { engine.skip() }
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.top, 10)
 
             Spacer(minLength: 20)
         }
@@ -243,26 +272,6 @@ struct PairwiseView: View {
                     .opacity(Double(magnitude))
                 )
         }
-    }
-
-    private var swipeHints: some View {
-        HStack {
-            HStack(spacing: 4) {
-                Image(systemName: "arrow.left")
-                    .font(.caption.bold())
-                Text("Pick top card")
-                    .font(.caption)
-            }
-            Spacer()
-            HStack(spacing: 4) {
-                Text("Pick this card")
-                    .font(.caption)
-                Image(systemName: "arrow.right")
-                    .font(.caption.bold())
-            }
-        }
-        .foregroundStyle(.secondary)
-        .padding(.horizontal, 24)
     }
 
     // MARK: - Compact Top Card


### PR DESCRIPTION
## Summary

Implements #79 — standard iOS selection paradigm replacing always-visible checkmarks.

- **"Select" toolbar button** enters selection mode; circle checkmarks slide in with spring animation
- **"Cancel" (leading toolbar)** exits selection mode and clears all selection  
- **"Done" (trailing toolbar)** same exit behavior — either button works
- **Expand/Collapse All** button returns when not in selection mode
- **History/Settings icons** hidden during selection mode for a focused, uncluttered toolbar
- **Circle checkmarks** only appear in selection mode; idle state matches Reminders.app's clean look
- **Shortcut**: tapping the disabled "Select Lists to Prioritise" bottom button when nothing is selected now enters selection mode directly
- **Session start** automatically exits selection mode

## Test plan

- [ ] Tap "Select" → circles animate in on all list rows; toolbar changes to Cancel + Done
- [ ] Tap list circles to toggle selection → "Prioritise N Lists" button activates
- [ ] Tap "Cancel" → circles animate out, selection cleared
- [ ] Tap "Done" → same as Cancel
- [ ] Tap "Select Lists to Prioritise" when nothing selected → enters selection mode
- [ ] Start a session → selection mode exits, fullscreen cover opens
- [ ] Regression: expand/collapse still works both in and out of selection mode

> **Note:** 2-finger drag-to-select is tracked separately — requires UIKit integration beyond SwiftUI's current `DisclosureGroup` support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)