### PR TITLE
AI seeding: criteria text, top-N limit, timeout + crash fixes

### DIFF
--- a/Sources/PairwiseReminders/Models/PairwiseSession.swift
+++ b/Sources/PairwiseReminders/Models/PairwiseSession.swift
@@ -108,6 +108,27 @@ final class PairwiseSession: ObservableObject {
         }
     }
 
+    /// Optional criteria text passed to AI seeding (e.g. "work tasks, deadlines this week").
+    var aiCriteria: String {
+        get { UserDefaults.standard.string(forKey: "ai_criteria") ?? "" }
+        set { UserDefaults.standard.set(newValue, forKey: "ai_criteria") }
+    }
+
+    /// Limit comparisons to the top N AI-ranked items. Nil = no limit (all items).
+    var aiTopN: Int? {
+        get {
+            let v = UserDefaults.standard.integer(forKey: "ai_top_n")
+            return v > 0 ? v : nil
+        }
+        set {
+            if let v = newValue, v > 0 {
+                UserDefaults.standard.set(v, forKey: "ai_top_n")
+            } else {
+                UserDefaults.standard.removeObject(forKey: "ai_top_n")
+            }
+        }
+    }
+
     // MARK: - Starting a Session
 
     /// Begins a session for the given lists. Fetches items, runs AI seeding, then
@@ -144,6 +165,12 @@ final class PairwiseSession: ObservableObject {
         // 2. Attempt AI seeding to set initial Elo ratings.
         await runSeeding(context: context)
 
+        // Guard: if the task was cancelled (e.g. user dismissed) while seeding, bail out cleanly.
+        guard !Task.isCancelled else {
+            phase = .idle
+            return
+        }
+
         // 3. Start the Elo engine with (possibly seeded) items.
         eloEngine.start(with: sessionItems)
         phase = .comparing
@@ -178,15 +205,16 @@ final class PairwiseSession: ObservableObject {
             )
         }
 
+        let criteria = aiCriteria.isEmpty ? nil : aiCriteria
         var seeds: [AnthropicService.SeededRank]?
 
         switch aiPreference {
         case .onDeviceFirst:
-            seeds = await tryOnDeviceSeeding(summaries: summaries)
-            if seeds == nil { seeds = await tryAPISeeding(summaries: summaries) }
+            seeds = await tryOnDeviceSeeding(summaries: summaries, criteria: criteria)
+            if seeds == nil { seeds = await tryAPISeeding(summaries: summaries, criteria: criteria) }
         case .apiFirst:
-            seeds = await tryAPISeeding(summaries: summaries)
-            if seeds == nil { seeds = await tryOnDeviceSeeding(summaries: summaries) }
+            seeds = await tryAPISeeding(summaries: summaries, criteria: criteria)
+            if seeds == nil { seeds = await tryOnDeviceSeeding(summaries: summaries, criteria: criteria) }
         case .none:
             break
         }
@@ -197,20 +225,28 @@ final class PairwiseSession: ObservableObject {
         }
 
         applySeedRatings(seeds, context: context)
+
+        // Truncate to top N if configured — only keep the highest-ranked items.
+        if let n = aiTopN, n > 0, sessionItems.count > n {
+            let topIDs = Set(seeds.sorted { $0.rank < $1.rank }.prefix(n).map(\.id))
+            sessionItems = sessionItems.filter { topIDs.contains($0.id) }
+        }
     }
 
     private func tryOnDeviceSeeding(
-        summaries: [AnthropicService.ReminderSummary]
+        summaries: [AnthropicService.ReminderSummary],
+        criteria: String?
     ) async -> [AnthropicService.SeededRank]? {
         guard FoundationModelService.isAvailable else { return nil }
-        return try? await FoundationModelService().seedRanking(summaries)
+        return try? await FoundationModelService().seedRanking(summaries, criteria: criteria)
     }
 
     private func tryAPISeeding(
-        summaries: [AnthropicService.ReminderSummary]
+        summaries: [AnthropicService.ReminderSummary],
+        criteria: String?
     ) async -> [AnthropicService.SeededRank]? {
         guard let apiKey = KeychainService.load(), !apiKey.isEmpty else { return nil }
-        return try? await AnthropicService(apiKey: apiKey).seedRanking(summaries)
+        return try? await AnthropicService(apiKey: apiKey).seedRanking(summaries, criteria: criteria)
     }
 
     /// Maps AI seed ranks and confidence scores into initial Elo ratings and K-factors,

--- a/Sources/PairwiseReminders/Services/AnthropicService.swift
+++ b/Sources/PairwiseReminders/Services/AnthropicService.swift
@@ -47,14 +47,17 @@ struct AnthropicService {
     ///
     /// The caller maps rank → Elo via: `1000 + (totalCount - rank) * 20`
     /// and sets kFactor via: `32 * (1 - confidence / 100)` (low confidence → high K).
-    func seedRanking(_ summaries: [ReminderSummary]) async throws -> [SeededRank] {
+    func seedRanking(_ summaries: [ReminderSummary], criteria: String? = nil) async throws -> [SeededRank] {
         guard !summaries.isEmpty else { return [] }
 
+        let criteriaClause = criteria.map { c in
+            " When ranking, specifically prioritise: \(c)."
+        } ?? ""
         let systemPrompt = """
         You are a productivity assistant. Given a list of tasks/reminders, rank them from most \
-        to least important, considering urgency, impact, and time-sensitivity. For each item, \
-        provide a confidence score 0–100 reflecting how certain you are of its position \
-        (100 = definitely right, 0 = could plausibly go anywhere in the list). \
+        to least important, considering urgency, impact, and time-sensitivity.\(criteriaClause) \
+        For each item, provide a confidence score 0–100 reflecting how certain you are of its \
+        position (100 = definitely right, 0 = could plausibly go anywhere in the list). \
         Return ALL items — do not filter any out.
         """
 

--- a/Sources/PairwiseReminders/Services/FoundationModelService.swift
+++ b/Sources/PairwiseReminders/Services/FoundationModelService.swift
@@ -17,14 +17,14 @@ struct FoundationModelService {
     // MARK: - Seeding
 
     /// Ranks items using the on-device language model and returns confidence-weighted results.
-    /// Throws if no capable model is available or if the model fails to produce parseable output.
-    func seedRanking(_ summaries: [AnthropicService.ReminderSummary]) async throws -> [AnthropicService.SeededRank] {
+    /// Throws if no capable model is available, times out, or the model fails to produce parseable output.
+    func seedRanking(_ summaries: [AnthropicService.ReminderSummary], criteria: String? = nil) async throws -> [AnthropicService.SeededRank] {
         guard !summaries.isEmpty else { return [] }
         guard FoundationModelService.isAvailable else {
             throw FoundationModelError.modelUnavailable
         }
 
-        let session = LanguageModelSession()
+        let modelSession = LanguageModelSession()
 
         let numberedList = summaries.enumerated().map { i, s in
             var line = "\(i + 1). [ID: \(s.id)] \(s.title)"
@@ -33,8 +33,12 @@ struct FoundationModelService {
             return line
         }.joined(separator: "\n")
 
+        let criteriaClause = criteria.map { c in
+            " When ranking, specifically prioritise: \(c)."
+        } ?? ""
+
         let prompt = """
-        You are a productivity assistant. Rank these tasks from most to least important. \
+        You are a productivity assistant. Rank these tasks from most to least important.\(criteriaClause) \
         For each, provide a confidence score 0-100 (100 = certain of position, 0 = could go anywhere). \
         Return ALL items. Respond ONLY with a JSON array, no other text:
         [{"id":"<id>","rank":<1-based>,"confidence":<0-100>}, ...]
@@ -43,8 +47,20 @@ struct FoundationModelService {
         \(numberedList)
         """
 
-        let response = try await session.respond(to: prompt)
-        return try parseResponse(response.content, summaries: summaries)
+        // Race the model response against a 10-second timeout to avoid hanging the seeding phase.
+        return try await withThrowingTaskGroup(of: [AnthropicService.SeededRank].self) { group in
+            group.addTask {
+                let response = try await modelSession.respond(to: prompt)
+                return try self.parseResponse(response.content, summaries: summaries)
+            }
+            group.addTask {
+                try await Task.sleep(for: .seconds(10))
+                throw FoundationModelError.timeout
+            }
+            let result = try await group.next()!
+            group.cancelAll()
+            return result
+        }
     }
 
     // MARK: - Parsing
@@ -88,12 +104,15 @@ struct FoundationModelService {
 
     enum FoundationModelError: LocalizedError {
         case modelUnavailable
+        case timeout
         case parseError(String)
 
         var errorDescription: String? {
             switch self {
             case .modelUnavailable:
                 return "On-device AI model is not available on this device."
+            case .timeout:
+                return "On-device model timed out."
             case .parseError(let msg):
                 return "Failed to parse on-device model response: \(msg)"
             }

--- a/Sources/PairwiseReminders/Views/HomeView.swift
+++ b/Sources/PairwiseReminders/Views/HomeView.swift
@@ -499,16 +499,35 @@ private struct PrioritiseOptionsSheet: View {
 
     @State private var rankingMode: PairwiseSession.RankingMode
     @State private var useAI: Bool
+    @State private var criteria: String
+    @State private var topNEnabled: Bool
+    @State private var topN: Int
+
+    private static let topNOptions = [5, 10, 15, 20, 30]
 
     init(listIDs: Set<String>, onStart: @escaping () -> Void) {
         self.listIDs = listIDs
         self.onStart = onStart
+        let defaults = UserDefaults.standard
         _rankingMode = State(initialValue:
-            PairwiseSession.RankingMode(rawValue: UserDefaults.standard.string(forKey: "ranking_mode") ?? "") ?? .overall
+            PairwiseSession.RankingMode(rawValue: defaults.string(forKey: "ranking_mode") ?? "") ?? .overall
         )
         _useAI = State(initialValue:
-            (UserDefaults.standard.string(forKey: "ai_preference") ?? "") != PairwiseSession.AIPreference.none.rawValue
+            (defaults.string(forKey: "ai_preference") ?? "") != PairwiseSession.AIPreference.none.rawValue
         )
+        _criteria = State(initialValue: defaults.string(forKey: "ai_criteria") ?? "")
+        let savedN = defaults.integer(forKey: "ai_top_n")
+        _topNEnabled = State(initialValue: savedN > 0)
+        _topN = State(initialValue: savedN > 0 ? savedN : 10)
+    }
+
+    private var aiAvailabilityNote: String {
+        let hasKey = (KeychainService.load() ?? "").isEmpty == false
+        let hasOnDevice = FoundationModelService.isAvailable
+        if hasOnDevice && hasKey { return "On-device AI + Anthropic API available." }
+        if hasOnDevice { return "On-device AI available." }
+        if hasKey { return "Anthropic API available." }
+        return "No AI backend configured. Add an API key in Settings."
     }
 
     var body: some View {
@@ -530,13 +549,42 @@ private struct PrioritiseOptionsSheet: View {
 
                 Section {
                     Toggle("Use AI to pre-rank items", isOn: $useAI)
+                    if useAI {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Prioritise criteria")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                            TextField("e.g. work tasks, deadlines this week", text: $criteria)
+                                .textFieldStyle(.plain)
+                        }
+                        .padding(.vertical, 2)
+
+                        Toggle("Limit to top N items", isOn: $topNEnabled)
+                        if topNEnabled {
+                            Picker("Items to compare", selection: $topN) {
+                                ForEach(Self.topNOptions, id: \.self) { n in
+                                    Text("\(n) items").tag(n)
+                                }
+                            }
+                        }
+                    }
                 } header: {
                     Text("AI seeding")
                 } footer: {
-                    Text(useAI
-                        ? "AI will estimate an initial ranking before you start comparing pairs."
-                        : "Items start with equal ratings. No AI is used.")
-                    .foregroundStyle(.secondary)
+                    if useAI {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(aiAvailabilityNote)
+                            if topNEnabled {
+                                Text("AI will rank all items but only the top \(topN) will be compared.")
+                            } else {
+                                Text("AI will estimate an initial ranking before you start comparing pairs.")
+                            }
+                        }
+                        .foregroundStyle(.secondary)
+                    } else {
+                        Text("Items start with equal ratings. No AI is used.")
+                            .foregroundStyle(.secondary)
+                    }
                 }
 
                 Section {
@@ -565,11 +613,11 @@ private struct PrioritiseOptionsSheet: View {
 
     private func applyAndStart() {
         session.rankingMode = rankingMode
+        session.aiCriteria = criteria
+        session.aiTopN = (useAI && topNEnabled) ? topN : nil
         if useAI {
-            // Prefer on-device if available, else API, using existing preference as a hint.
-            if session.aiPreference == .none {
-                session.aiPreference = FoundationModelService.isAvailable ? .onDeviceFirst : .apiFirst
-            }
+            // Always recompute — pick the best available backend.
+            session.aiPreference = FoundationModelService.isAvailable ? .onDeviceFirst : .apiFirst
         } else {
             session.aiPreference = .none
         }


### PR DESCRIPTION
## Summary

- **Criteria input**: Users can now type e.g. "work tasks, deadlines this week" in Prioritise Options — passed to both Anthropic API and on-device AI to steer initial ranking
- **Top-N limit**: Optional toggle to compare only the top N AI-ranked items (5/10/15/20/30) — great for large lists where you only care about the frontrunners
- **On-device timeout fix** (#82): `FoundationModelService.seedRanking` now races against a 10-second timeout via `withThrowingTaskGroup` — prevents the seeding phase from hanging indefinitely
- **Cancellation guard** (#81): `PairwiseSession.start()` checks `Task.isCancelled` after seeding completes and returns to `.idle` instead of crashing on into the comparing phase
- **AI preference bug** (#82): `applyAndStart()` always recomputes the best available backend (on-device vs API) instead of only when preference was `.none`
- **AI availability note**: `PrioritiseOptionsSheet` now shows which backends are actually available

## Test plan

- [ ] Open Prioritise Options — confirm criteria field and top-N toggle appear when AI is enabled
- [ ] Enter criteria text, start a session — verify seeding uses it (check ranked order makes sense)
- [ ] Enable top-N = 5 with a larger list — verify only 5 items appear in pairwise comparisons
- [ ] Dismiss the Prioritise sheet mid-seeding — verify app doesn't crash and returns to home
- [ ] Disable AI — verify criteria/top-N controls hide, session starts immediately with no seeding
- [ ] AI availability note reflects actual state (no key = "No AI backend configured")

🤖 Generated with [Claude Code](https://claude.com/claude-code)