### PR TITLE
Individual reminder selection — pick specific items, not just whole lists

### DIFF
--- a/Sources/PairwiseReminders/Models/PairwiseSession.swift
+++ b/Sources/PairwiseReminders/Models/PairwiseSession.swift
@@ -176,6 +176,37 @@ final class PairwiseSession: ObservableObject {
         phase = .comparing
     }
 
+    /// Begins a session for a specific pre-loaded set of items (individual selection path).
+    /// Skips the fetch step — items are already in memory.
+    func start(
+        items: [ReminderItem],
+        eloEngine: EloEngine,
+        context: ModelContext
+    ) async {
+        selectedListIDs = Set(items.compactMap { $0.ekReminder.calendar?.calendarIdentifier })
+        sessionItems = items
+        rankedItems = []
+        seedingFailed = false
+        seedingError = nil
+        eloEngine.reset()
+        phase = .seeding
+
+        guard !sessionItems.isEmpty else {
+            phase = .idle
+            return
+        }
+
+        await runSeeding(context: context)
+
+        guard !Task.isCancelled else {
+            phase = .idle
+            return
+        }
+
+        eloEngine.start(with: sessionItems)
+        phase = .comparing
+    }
+
     /// Called by PairwiseView when the user taps "Done for now" or the engine converges.
     func finish(eloEngine: EloEngine, context: ModelContext) {
         rankedItems = eloEngine.finish(context: context)

--- a/Sources/PairwiseReminders/Views/HomeView.swift
+++ b/Sources/PairwiseReminders/Views/HomeView.swift
@@ -38,6 +38,7 @@ struct HomeView: View {
 
     @State private var expandedListIDs: Set<String> = []
     @State private var selectedListIDs: Set<String> = []
+    @State private var selectedItemIDs: Set<String> = []
     @State private var isSelecting: Bool = false
     @State private var itemsByList: [String: [ReminderItem]] = [:]
     @State private var loadingListIDs: Set<String> = []
@@ -121,6 +122,7 @@ struct HomeView: View {
                         Button("Cancel") {
                             isSelecting = false
                             selectedListIDs = []
+                            selectedItemIDs = []
                         }
                         .font(.subheadline)
                     } else if groupingMode == .byList {
@@ -150,7 +152,7 @@ struct HomeView: View {
                         }
                         Button(isSelecting ? "Done" : "Select") {
                             isSelecting.toggle()
-                            if !isSelecting { selectedListIDs = [] }
+                            if !isSelecting { selectedListIDs = []; selectedItemIDs = [] }
                         }
                         .font(.subheadline.weight(isSelecting ? .semibold : .regular))
                     }
@@ -166,17 +168,31 @@ struct HomeView: View {
                 HistoryView()
             }
             .sheet(isPresented: $showPrioritiseOptions) {
-                PrioritiseOptionsSheet(listIDs: selectedListIDs) {
+                PrioritiseOptionsSheet(selectionLabel: prioritiseLabel) {
                     showPrioritiseOptions = false
                     showPrioritise = true
                     isSelecting = false
-                    Task {
-                        await session.start(
-                            listIDs: selectedListIDs,
-                            remindersManager: remindersManager,
-                            eloEngine: eloEngine,
-                            context: modelContext
-                        )
+                    if !selectedItemIDs.isEmpty {
+                        // Item-level selection: pass pre-loaded items directly.
+                        let ids = selectedItemIDs
+                        let items = itemsByList.values.flatMap { $0 }.filter { ids.contains($0.id) }
+                        selectedItemIDs = []
+                        Task {
+                            await session.start(
+                                items: items,
+                                eloEngine: eloEngine,
+                                context: modelContext
+                            )
+                        }
+                    } else {
+                        Task {
+                            await session.start(
+                                listIDs: selectedListIDs,
+                                remindersManager: remindersManager,
+                                eloEngine: eloEngine,
+                                context: modelContext
+                            )
+                        }
                     }
                 }
                 .presentationDetents([.medium])
@@ -269,14 +285,24 @@ struct HomeView: View {
                     .listRowBackground(Color.clear)
             } else {
                 ForEach(Array(ranked.enumerated()), id: \.element.id) { index, item in
-                    ExpandedItemRow(item: item, rank: index + 1, eloMin: eloMin, eloMax: eloMax)
-                        .contentShape(Rectangle())
-                        .onTapGesture { selectedList = calendar }
+                    ExpandedItemRow(
+                        item: item, rank: index + 1, eloMin: eloMin, eloMax: eloMax,
+                        isSelecting: isSelecting, isSelected: selectedItemIDs.contains(item.id)
+                    )
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        if isSelecting { toggleItemSelect(item.id) } else { selectedList = calendar }
+                    }
                 }
                 ForEach(unranked, id: \.id) { item in
-                    ExpandedItemRow(item: item, rank: nil, eloMin: eloMin, eloMax: eloMax)
-                        .contentShape(Rectangle())
-                        .onTapGesture { selectedList = calendar }
+                    ExpandedItemRow(
+                        item: item, rank: nil, eloMin: eloMin, eloMax: eloMax,
+                        isSelecting: isSelecting, isSelected: selectedItemIDs.contains(item.id)
+                    )
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        if isSelecting { toggleItemSelect(item.id) } else { selectedList = calendar }
+                    }
                 }
             }
         }
@@ -297,24 +323,36 @@ struct HomeView: View {
                     ExpandedItemRow(
                         item: item, rank: index + 1,
                         eloMin: globalEloMin, eloMax: globalEloMax,
-                        showListName: true
+                        showListName: true,
+                        isSelecting: isSelecting,
+                        isSelected: selectedItemIDs.contains(item.id)
                     )
                     .contentShape(Rectangle())
                     .onTapGesture {
-                        selectedList = remindersManager.lists
-                            .first { $0.calendarIdentifier == item.ekReminder.calendar?.calendarIdentifier }
+                        if isSelecting {
+                            toggleItemSelect(item.id)
+                        } else {
+                            selectedList = remindersManager.lists
+                                .first { $0.calendarIdentifier == item.ekReminder.calendar?.calendarIdentifier }
+                        }
                     }
                 }
                 ForEach(unranked, id: \.id) { item in
                     ExpandedItemRow(
                         item: item, rank: nil,
                         eloMin: globalEloMin, eloMax: globalEloMax,
-                        showListName: true
+                        showListName: true,
+                        isSelecting: isSelecting,
+                        isSelected: selectedItemIDs.contains(item.id)
                     )
                     .contentShape(Rectangle())
                     .onTapGesture {
-                        selectedList = remindersManager.lists
-                            .first { $0.calendarIdentifier == item.ekReminder.calendar?.calendarIdentifier }
+                        if isSelecting {
+                            toggleItemSelect(item.id)
+                        } else {
+                            selectedList = remindersManager.lists
+                                .first { $0.calendarIdentifier == item.ekReminder.calendar?.calendarIdentifier }
+                        }
                     }
                 }
             }
@@ -341,24 +379,36 @@ struct HomeView: View {
                             ExpandedItemRow(
                                 item: item, rank: nil,
                                 eloMin: globalEloMin, eloMax: globalEloMax,
-                                showListName: true
+                                showListName: true,
+                                isSelecting: isSelecting,
+                                isSelected: selectedItemIDs.contains(item.id)
                             )
                             .contentShape(Rectangle())
                             .onTapGesture {
-                                selectedList = remindersManager.lists
-                                    .first { $0.calendarIdentifier == item.ekReminder.calendar?.calendarIdentifier }
+                                if isSelecting {
+                                    toggleItemSelect(item.id)
+                                } else {
+                                    selectedList = remindersManager.lists
+                                        .first { $0.calendarIdentifier == item.ekReminder.calendar?.calendarIdentifier }
+                                }
                             }
                         }
                         ForEach(unranked, id: \.id) { item in
                             ExpandedItemRow(
                                 item: item, rank: nil,
                                 eloMin: globalEloMin, eloMax: globalEloMax,
-                                showListName: true
+                                showListName: true,
+                                isSelecting: isSelecting,
+                                isSelected: selectedItemIDs.contains(item.id)
                             )
                             .contentShape(Rectangle())
                             .onTapGesture {
-                                selectedList = remindersManager.lists
-                                    .first { $0.calendarIdentifier == item.ekReminder.calendar?.calendarIdentifier }
+                                if isSelecting {
+                                    toggleItemSelect(item.id)
+                                } else {
+                                    selectedList = remindersManager.lists
+                                        .first { $0.calendarIdentifier == item.ekReminder.calendar?.calendarIdentifier }
+                                }
                             }
                         }
                     }
@@ -371,10 +421,12 @@ struct HomeView: View {
 
     // MARK: - Prioritise Button
 
+    private var hasSelection: Bool { !selectedListIDs.isEmpty || !selectedItemIDs.isEmpty }
+
     private var prioritiseButton: some View {
         VStack(spacing: 0) {
             Button {
-                if selectedListIDs.isEmpty {
+                if !hasSelection {
                     // Shortcut: tapping the button starts selection mode
                     isSelecting = true
                 } else {
@@ -385,8 +437,8 @@ struct HomeView: View {
                     .font(.headline)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 16)
-                    .background(selectedListIDs.isEmpty ? Color(.systemGray4) : Color.blue)
-                    .foregroundStyle(selectedListIDs.isEmpty ? Color.secondary : .white)
+                    .background(hasSelection ? Color.blue : Color(.systemGray4))
+                    .foregroundStyle(hasSelection ? .white : Color.secondary)
                     .clipShape(RoundedRectangle(cornerRadius: 14))
             }
             .padding(.horizontal)
@@ -396,9 +448,15 @@ struct HomeView: View {
     }
 
     private var prioritiseLabel: String {
-        if selectedListIDs.isEmpty { return "Select Lists to Prioritise" }
-        let n = selectedListIDs.count
-        return "Prioritise \(n == 1 ? "1 List" : "\(n) Lists")"
+        if !selectedItemIDs.isEmpty {
+            let n = selectedItemIDs.count
+            return "Prioritise \(n == 1 ? "1 Item" : "\(n) Items")"
+        }
+        if !selectedListIDs.isEmpty {
+            let n = selectedListIDs.count
+            return "Prioritise \(n == 1 ? "1 List" : "\(n) Lists")"
+        }
+        return "Select to Prioritise"
     }
 
     // MARK: - Empty State
@@ -429,6 +487,14 @@ struct HomeView: View {
             selectedListIDs.remove(id)
         } else {
             selectedListIDs.insert(id)
+        }
+    }
+
+    private func toggleItemSelect(_ id: String) {
+        if selectedItemIDs.contains(id) {
+            selectedItemIDs.remove(id)
+        } else {
+            selectedItemIDs.insert(id)
         }
     }
 
@@ -491,7 +557,7 @@ private struct PrioritiseFlow: View {
 /// Tapping Start applies settings and triggers the session.
 private struct PrioritiseOptionsSheet: View {
 
-    let listIDs: Set<String>
+    let selectionLabel: String
     let onStart: () -> Void
 
     @EnvironmentObject private var session: PairwiseSession
@@ -505,8 +571,8 @@ private struct PrioritiseOptionsSheet: View {
 
     private static let topNOptions = [5, 10, 15, 20, 30]
 
-    init(listIDs: Set<String>, onStart: @escaping () -> Void) {
-        self.listIDs = listIDs
+    init(selectionLabel: String, onStart: @escaping () -> Void) {
+        self.selectionLabel = selectionLabel
         self.onStart = onStart
         let defaults = UserDefaults.standard
         _rankingMode = State(initialValue:
@@ -591,7 +657,7 @@ private struct PrioritiseOptionsSheet: View {
                     Button {
                         applyAndStart()
                     } label: {
-                        Text("Start Prioritising \(listIDs.count == 1 ? "1 List" : "\(listIDs.count) Lists")")
+                        Text("Start Prioritising \(selectionLabel)")
                             .font(.headline)
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, 4)
@@ -698,6 +764,8 @@ private struct ExpandedItemRow: View {
     let eloMax: Double
     /// Show the list name as a subtitle — useful in flat/date grouping modes.
     var showListName: Bool = false
+    var isSelecting: Bool = false
+    var isSelected: Bool = false
 
     private var eloStrength: Double {
         guard rank != nil, eloMax > eloMin else { return 0 }
@@ -712,8 +780,13 @@ private struct ExpandedItemRow: View {
 
     var body: some View {
         HStack(spacing: 10) {
-            // Rank badge for compared items; plain circle for unranked (matches Reminders.app)
-            if let r = rank {
+            // In selection mode: checkmark circle. Otherwise: rank badge or plain circle.
+            if isSelecting {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(isSelected ? .blue : Color(.tertiaryLabel))
+                    .font(.title3)
+                    .animation(.spring(response: 0.2), value: isSelected)
+            } else if let r = rank {
                 ZStack {
                     Circle()
                         .fill(badgeColor(r))


### PR DESCRIPTION
## Summary

- **Per-item selection**: in selection mode, individual reminder rows now show checkmark circles — tap any row to include/exclude that item from your Prioritise session
- **Works across all grouping modes**: List (expanded rows), All (flat), and Due Date all support item-level taps when Select mode is active
- **New session start path**: `PairwiseSession.start(items:eloEngine:context:)` accepts pre-loaded items directly, bypassing the list-level EventKit fetch — keeps seeding, cancellation guard, and top-N truncation
- **Smart button label**: "Prioritise 5 Items" vs "Prioritise 2 Lists" depending on what's selected; whole-list and item selection remain independent (item selection takes priority)
- **Clean exit**: Cancel and Done both clear both selection sets

## Test plan

- [ ] Tap Select → expand a list → tap individual rows — each shows a checkmark; Prioritise button updates to "N Items"
- [ ] Select items from multiple lists — all appear as a combined item count
- [ ] Tap Prioritise — options sheet opens with correct label; starting session only compares selected items
- [ ] Select a whole list (header circle) while items are also selected — confirm both flows work independently
- [ ] In flat/All mode with Select active — tap rows to select individual items across lists
- [ ] In Due Date mode with Select active — same behaviour
- [ ] Cancel clears all selection state; Done also clears and exits selection mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)