### PR TITLE
Visual polish: Elo bars in ListDetailView + HIG-compliant pairwise buttons

### DIFF
--- a/Sources/PairwiseReminders/Views/ListDetailView.swift
+++ b/Sources/PairwiseReminders/Views/ListDetailView.swift
@@ -67,9 +67,11 @@ struct ListDetailView: View {
     private var itemList: some View {
         List {
             if !rankedItems.isEmpty {
+                let eloMin = rankedItems.last?.eloRating ?? 1000
+                let eloMax = rankedItems.first?.eloRating ?? 1000
                 Section("Ranked — \(rankedItems.count)") {
                     ForEach(Array(rankedItems.enumerated()), id: \.element.id) { index, item in
-                        RankedRowView(item: item, rank: index + 1, total: rankedItems.count)
+                        RankedRowView(item: item, rank: index + 1, eloMin: eloMin, eloMax: eloMax)
                             .swipeActions(edge: .leading) {
                                 Button {
                                     complete(item)
@@ -246,10 +248,19 @@ struct ListDetailView: View {
 private struct RankedRowView: View {
     let item: ReminderItem
     let rank: Int
-    let total: Int
+    let eloMin: Double
+    let eloMax: Double
 
-    private var priorityLabel: String { item.priorityLabel(totalCount: total) }
-    private var priorityColor: Color  { mapColor(item.priorityColor(totalCount: total)) }
+    private var eloStrength: Double {
+        guard eloMax > eloMin else { return 0 }
+        return max(0, min(1, (item.eloRating - eloMin) / (eloMax - eloMin)))
+    }
+
+    private var barTint: Color {
+        if eloStrength > 0.66 { return .blue }
+        if eloStrength > 0.33 { return .indigo }
+        return Color(.systemGray3)
+    }
 
     var body: some View {
         HStack(spacing: 12) {
@@ -262,33 +273,27 @@ private struct RankedRowView: View {
                     .foregroundStyle(.white)
             }
 
-            VStack(alignment: .leading, spacing: 3) {
+            VStack(alignment: .leading, spacing: 4) {
                 Text(item.title)
                     .font(.body)
                     .lineLimit(2)
 
                 HStack(spacing: 6) {
+                    if let due = item.dueDate {
+                        Label(due.formatted(.dateTime.day().month()), systemImage: "calendar")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text("·").foregroundStyle(.tertiary).font(.caption)
+                    }
                     Text(item.listName)
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                    if let due = item.dueDate {
-                        Text("·").foregroundStyle(.tertiary).font(.caption)
-                        Text(due.formatted(.dateTime.day().month()))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
                 }
+
+                ProgressView(value: eloStrength)
+                    .tint(barTint)
+                    .frame(height: 3)
             }
-
-            Spacer()
-
-            Text(priorityLabel)
-                .font(.caption.bold())
-                .padding(.horizontal, 7)
-                .padding(.vertical, 3)
-                .background(priorityColor.opacity(0.15))
-                .foregroundStyle(priorityColor)
-                .clipShape(RoundedRectangle(cornerRadius: 5))
         }
         .padding(.vertical, 3)
     }
@@ -299,15 +304,6 @@ private struct RankedRowView: View {
         case 2: return .indigo
         case 3: return .purple
         default: return Color(.systemGray3)
-        }
-    }
-
-    private func mapColor(_ c: ReminderItem.PriorityColor) -> Color {
-        switch c {
-        case .high:   return .red
-        case .medium: return .orange
-        case .low:    return .yellow
-        case .none:   return Color(.secondaryLabel)
         }
     }
 }

--- a/Sources/PairwiseReminders/Views/PairwiseView.swift
+++ b/Sources/PairwiseReminders/Views/PairwiseView.swift
@@ -66,7 +66,9 @@ struct PairwiseView: View {
                     session.finish(eloEngine: engine, context: modelContext)
                 }
                 .font(.subheadline)
-                .foregroundStyle(.secondary)
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .tint(.secondary)
 
                 Spacer()
 
@@ -210,16 +212,39 @@ struct PairwiseView: View {
             .padding(.horizontal)
             .padding(.top, 12)
 
-            // Secondary actions
-            HStack(spacing: 20) {
-                Button("About equal") { engine.equal() }
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                Text("·").foregroundStyle(.tertiary)
-                Button("Skip") { engine.skip() }
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
+            // Secondary actions — equal-width bordered buttons
+            HStack(spacing: 10) {
+                Button { engine.equal() } label: {
+                    Text("About equal")
+                        .font(.subheadline)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 11)
+                        .background(Color(.secondarySystemBackground))
+                        .foregroundStyle(.secondary)
+                        .clipShape(RoundedRectangle(cornerRadius: 13))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 13)
+                                .strokeBorder(Color(.separator), lineWidth: 0.5)
+                        )
+                }
+                .buttonStyle(.plain)
+
+                Button { engine.skip() } label: {
+                    Text("Skip")
+                        .font(.subheadline)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 11)
+                        .background(Color(.secondarySystemBackground))
+                        .foregroundStyle(.secondary)
+                        .clipShape(RoundedRectangle(cornerRadius: 13))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 13)
+                                .strokeBorder(Color(.separator), lineWidth: 0.5)
+                        )
+                }
+                .buttonStyle(.plain)
             }
+            .padding(.horizontal)
             .padding(.top, 10)
 
             Spacer(minLength: 20)


### PR DESCRIPTION
## Summary

### #78 — Priority pills → Elo strength bars in ListDetailView
- `RankedRowView` drops the coloured H/M/L pill badge entirely
- Replaced with a `ProgressView` bar showing relative Elo strength within the list (same pattern as `ExpandedItemRow` in HomeView)
- Bar tint: blue (top third) → indigo (middle) → grey (lower third)
- Due date moved before list name in the subtitle row for better scannability

### #67 — HIG-compliant buttons in PairwiseView
- **"Done for now"**: now uses `.buttonStyle(.bordered) .controlSize(.small)` — clearly a tappable button, not just faded text
- **"About equal" / "Skip"**: replaced plain text links with equal-width bordered buttons — same corner radius and background as "Top one"/"This one" but in secondary/muted colouring; visually the 4 choice buttons now form a consistent 2×2 grid

## Test plan

- [ ] Open a list detail view with ranked items — confirm pill labels are gone, Elo bars appear and vary in width/colour
- [ ] Item at rank 1 has a blue bar at full width; last ranked item has a grey bar near-empty
- [ ] Open pairwise session — "Done for now" renders as a bordered capsule button
- [ ] "About equal" and "Skip" render as matching bordered buttons alongside "Top one" / "This one"
- [ ] All four choice buttons respond to taps as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)