### PR TITLE
HIG review: system buttons, swipe affordance, touch icons

### DIFF
--- a/Sources/PairwiseReminders/Views/HomeView.swift
+++ b/Sources/PairwiseReminders/Views/HomeView.swift
@@ -384,11 +384,10 @@ struct HomeView: View {
                 Text(prioritiseLabel)
                     .font(.headline)
                     .frame(maxWidth: .infinity)
-                    .padding(.vertical, 16)
-                    .background(selectedListIDs.isEmpty ? Color(.systemGray4) : Color.blue)
-                    .foregroundStyle(selectedListIDs.isEmpty ? Color.secondary : .white)
-                    .clipShape(RoundedRectangle(cornerRadius: 14))
             }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .tint(selectedListIDs.isEmpty ? Color(.systemGray4) : .blue)
             .padding(.horizontal)
             .padding(.vertical, 12)
         }

--- a/Sources/PairwiseReminders/Views/PairwiseView.swift
+++ b/Sources/PairwiseReminders/Views/PairwiseView.swift
@@ -65,9 +65,7 @@ struct PairwiseView: View {
                 Button("Done for now") {
                     session.finish(eloEngine: engine, context: modelContext)
                 }
-                .font(.subheadline)
                 .buttonStyle(.bordered)
-                .controlSize(.small)
                 .tint(.secondary)
 
                 Spacer()
@@ -169,83 +167,59 @@ struct PairwiseView: View {
                 .padding(.horizontal)
                 .simultaneousGesture(LongPressGesture().onEnded { _ in editingItem = bottomItem })
 
+            // Swipe affordance hint — static cue that the card is swipeable
+            HStack(spacing: 6) {
+                Image(systemName: "arrow.left")
+                Text("Swipe to choose")
+                Image(systemName: "arrow.right")
+            }
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+            .padding(.top, 8)
+
             // Explicit choice buttons — clear affordance, swipe still works as a shortcut
             HStack(spacing: 10) {
                 Button {
                     engine.choose(winner: topItem)
                 } label: {
-                    HStack(spacing: 6) {
-                        Image(systemName: "arrow.up")
-                            .font(.subheadline.bold())
-                        Text("Top one")
-                            .font(.subheadline.weight(.medium))
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 13)
-                    .background(Color(.secondarySystemBackground))
-                    .foregroundStyle(.primary)
-                    .clipShape(RoundedRectangle(cornerRadius: 13))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 13)
-                            .strokeBorder(Color(.separator), lineWidth: 0.5)
-                    )
+                    Label("Top one", systemImage: "arrow.up")
+                        .frame(maxWidth: .infinity)
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.bordered)
+                .controlSize(.large)
 
                 Button {
                     engine.choose(winner: bottomItem)
                 } label: {
-                    HStack(spacing: 6) {
-                        Image(systemName: "arrow.down")
-                            .font(.subheadline.bold())
-                        Text("This one")
-                            .font(.subheadline.weight(.medium))
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 13)
-                    .background(Color.blue)
-                    .foregroundStyle(.white)
-                    .clipShape(RoundedRectangle(cornerRadius: 13))
+                    Label("This one", systemImage: "arrow.down")
+                        .frame(maxWidth: .infinity)
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
             }
             .padding(.horizontal)
-            .padding(.top, 12)
+            .padding(.top, 4)
 
-            // Secondary actions — equal-width bordered buttons
+            // Secondary actions
             HStack(spacing: 10) {
                 Button { engine.equal() } label: {
                     Text("About equal")
-                        .font(.subheadline)
                         .frame(maxWidth: .infinity)
-                        .padding(.vertical, 11)
-                        .background(Color(.secondarySystemBackground))
-                        .foregroundStyle(.secondary)
-                        .clipShape(RoundedRectangle(cornerRadius: 13))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 13)
-                                .strokeBorder(Color(.separator), lineWidth: 0.5)
-                        )
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+                .tint(.secondary)
 
                 Button { engine.skip() } label: {
                     Text("Skip")
-                        .font(.subheadline)
                         .frame(maxWidth: .infinity)
-                        .padding(.vertical, 11)
-                        .background(Color(.secondarySystemBackground))
-                        .foregroundStyle(.secondary)
-                        .clipShape(RoundedRectangle(cornerRadius: 13))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 13)
-                                .strokeBorder(Color(.separator), lineWidth: 0.5)
-                        )
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+                .tint(.secondary)
             }
             .padding(.horizontal)
-            .padding(.top, 10)
+            .padding(.top, 8)
 
             Spacer(minLength: 20)
         }
@@ -314,7 +288,7 @@ struct PairwiseView: View {
             }
             Spacer()
             VStack(alignment: .trailing, spacing: 3) {
-                Image(systemName: "cursorarrow.click")
+                Image(systemName: "hand.tap")
                     .font(.subheadline)
                     .foregroundStyle(.blue.opacity(0.6))
                 Text("Tap to pick")

--- a/Sources/PairwiseReminders/Views/ResultsView.swift
+++ b/Sources/PairwiseReminders/Views/ResultsView.swift
@@ -374,8 +374,8 @@ struct ApplySheet: View {
             Toggle("Set priorities", isOn: $options.applyPriorities)
             if options.applyPriorities {
                 Picker("Mode", selection: $options.priorityMode) {
-                    Text("Distribute").tag(ApplyOptions.PriorityMode.tiered)
-                    Text("Top N only").tag(ApplyOptions.PriorityMode.topN)
+                    Text("Tiered").tag(ApplyOptions.PriorityMode.tiered)
+                    Text("Top N").tag(ApplyOptions.PriorityMode.topN)
                 }
                 .pickerStyle(.segmented)
                 if options.priorityMode == .topN {

--- a/Sources/PairwiseReminders/Views/ResultsView.swift
+++ b/Sources/PairwiseReminders/Views/ResultsView.swift
@@ -112,11 +112,9 @@ struct ResultsView: View {
                 Label("Apply to Reminders…", systemImage: "square.and.arrow.down")
                     .font(.headline)
                     .frame(maxWidth: .infinity)
-                    .padding()
-                    .background(Color.blue)
-                    .foregroundStyle(.white)
-                    .clipShape(RoundedRectangle(cornerRadius: 14))
             }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
             .padding(.horizontal)
 
             Button("Done") {


### PR DESCRIPTION
## Summary

- **PairwiseView**: Replace all custom-styled plain buttons with system `.bordered` / `.borderedProminent` at `controlSize(.large)` — these respect dark mode, Dynamic Type, and iOS 26 liquid glass styling automatically
- **PairwiseView**: Add a static "← Swipe to choose →" hint below the bottom card so swipeability is discoverable before the user tries
- **PairwiseView**: Replace `cursorarrow.click` (a cursor/pointer icon) with `hand.tap` for the top card's tap affordance — more appropriate for touch
- **PairwiseView**: Remove `controlSize(.small)` from "Done for now" so it's a normal-height button
- **ResultsView**: Convert the custom hardcoded-blue "Apply to Reminders…" button to `.borderedProminent`
- **HomeView**: Convert the bottom prioritise button to `.borderedProminent` with a conditional tint (gray when nothing selected, blue when lists selected)

## Test plan

- [ ] PairwiseView: buttons render correctly in light and dark mode
- [ ] PairwiseView: swipe hint is visible below the bottom card
- [ ] PairwiseView: "Top one" / "This one" / "About equal" / "Skip" all function correctly
- [ ] PairwiseView: "Done for now" taps correctly and exits the session
- [ ] PairwiseView: swiping the bottom card still works as before
- [ ] ResultsView: "Apply to Reminders…" button is prominent and opens the apply sheet
- [ ] HomeView: prioritise button shows gray when no lists selected, blue when selected; tapping when empty enters selection mode

Closes #66, #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)