### PR TITLE
UI polish: PairwiseView declutter + HomeView sparkline inline

### DIFF
--- a/Sources/PairwiseReminders/Views/HomeView.swift
+++ b/Sources/PairwiseReminders/Views/HomeView.swift
@@ -441,9 +441,7 @@ struct HomeView: View {
                     .foregroundStyle(hasSelection ? .white : Color.secondary)
                     .clipShape(RoundedRectangle(cornerRadius: 14))
             }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.large)
-            .tint(selectedListIDs.isEmpty ? Color(.systemGray4) : .blue)
+            .buttonStyle(.plain)
             .padding(.horizontal)
             .padding(.vertical, 12)
         }
@@ -710,17 +708,15 @@ private struct CollapsedListHeader: View {
 
     var body: some View {
         HStack(spacing: 10) {
-            VStack(alignment: .leading, spacing: 6) {
-                HStack(spacing: 8) {
-                    Circle()
-                        .fill(Color(cgColor: calendar.cgColor))
-                        .frame(width: 10, height: 10)
-                    Text(calendar.title)
-                        .font(.body.bold())
-                        .foregroundStyle(.primary)
-                }
-                eloSparkline
-            }
+            Circle()
+                .fill(Color(cgColor: calendar.cgColor))
+                .frame(width: 10, height: 10)
+            Text(calendar.title)
+                .font(.body.bold())
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+            eloSparkline
+                .fixedSize(horizontal: true, vertical: false)
 
             Spacer()
 

--- a/Sources/PairwiseReminders/Views/PairwiseView.swift
+++ b/Sources/PairwiseReminders/Views/PairwiseView.swift
@@ -55,6 +55,23 @@ struct PairwiseView: View {
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
         }
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Menu {
+                    if engine.canUndo {
+                        Button("Undo", systemImage: "arrow.uturn.backward") {
+                            engine.undo()
+                        }
+                    }
+                    Button("Done for now", systemImage: "xmark") {
+                        session.finish(eloEngine: engine, context: modelContext)
+                    }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                }
+            }
+        }
     }
 
     // MARK: - Header
@@ -62,37 +79,22 @@ struct PairwiseView: View {
     private var headerBar: some View {
         VStack(spacing: 10) {
             HStack {
-                Button("Done for now") {
-                    session.finish(eloEngine: engine, context: modelContext)
-                }
-                .buttonStyle(.bordered)
-                .tint(.secondary)
-
                 Spacer()
-
                 Text(session.rankingMode.comparisonQuestion)
                     .font(.headline)
-
                 Spacer()
-
-                HStack(spacing: 12) {
-                    if engine.canUndo {
-                        Button { engine.undo() } label: {
-                            Image(systemName: "arrow.uturn.backward")
-                        }
-                        .foregroundStyle(.secondary)
+            }
+            .overlay(alignment: .trailing) {
+                Group {
+                    if engine.estimatedRemaining > 0 {
+                        Text("\(engine.estimatedRemaining) left")
+                    } else {
+                        Text("Almost done")
                     }
-                    Group {
-                        if engine.estimatedRemaining > 0 {
-                            Text("\(engine.estimatedRemaining) left")
-                        } else {
-                            Text("Almost done")
-                        }
-                    }
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .monospacedDigit()
                 }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
             }
             .padding(.horizontal)
             .padding(.top)
@@ -167,59 +169,14 @@ struct PairwiseView: View {
                 .padding(.horizontal)
                 .simultaneousGesture(LongPressGesture().onEnded { _ in editingItem = bottomItem })
 
-            // Swipe affordance hint — static cue that the card is swipeable
-            HStack(spacing: 6) {
-                Image(systemName: "arrow.left")
-                Text("Swipe to choose")
-                Image(systemName: "arrow.right")
+            // Secondary action
+            Button { engine.equal() } label: {
+                Text("About equal")
             }
-            .font(.caption2)
-            .foregroundStyle(.tertiary)
-            .padding(.top, 8)
-
-            // Explicit choice buttons — clear affordance, swipe still works as a shortcut
-            HStack(spacing: 10) {
-                Button {
-                    engine.choose(winner: topItem)
-                } label: {
-                    Label("Top one", systemImage: "arrow.up")
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.large)
-
-                Button {
-                    engine.choose(winner: bottomItem)
-                } label: {
-                    Label("This one", systemImage: "arrow.down")
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.large)
-            }
-            .padding(.horizontal)
-            .padding(.top, 4)
-
-            // Secondary actions
-            HStack(spacing: 10) {
-                Button { engine.equal() } label: {
-                    Text("About equal")
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.large)
-                .tint(.secondary)
-
-                Button { engine.skip() } label: {
-                    Text("Skip")
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.large)
-                .tint(.secondary)
-            }
-            .padding(.horizontal)
-            .padding(.top, 8)
+            .buttonStyle(.bordered)
+            .controlSize(.regular)
+            .tint(.secondary)
+            .padding(.top, 12)
 
             Spacer(minLength: 20)
         }
@@ -232,6 +189,7 @@ struct PairwiseView: View {
 
         return CardBody(item: item)
             .overlay(swipeOverlay(normalized: normalized))
+            .overlay(RoundedRectangle(cornerRadius: 18).stroke(Color.blue.opacity(0.3), lineWidth: 2))
             .rotationEffect(.degrees(Double(normalized) * 6))
             .offset(x: dragOffset.width * 0.5)
             .gesture(
@@ -287,14 +245,6 @@ struct PairwiseView: View {
                     .foregroundStyle(.secondary)
             }
             Spacer()
-            VStack(alignment: .trailing, spacing: 3) {
-                Image(systemName: "hand.tap")
-                    .font(.subheadline)
-                    .foregroundStyle(.blue.opacity(0.6))
-                Text("Tap to pick")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-            }
         }
         .padding(14)
         .background(
@@ -302,7 +252,7 @@ struct PairwiseView: View {
                 .fill(Color(.secondarySystemBackground))
                 .overlay(
                     RoundedRectangle(cornerRadius: 14)
-                        .stroke(Color.blue.opacity(0.18), lineWidth: 1)
+                        .stroke(Color(.separator).opacity(0.3), lineWidth: 1)
                 )
         )
     }


### PR DESCRIPTION
## Summary

- **PairwiseView**: Significant declutter — removes redundant buttons/hints, moves "Done for now" + undo to overflow menu (`···`), adds blue border to active (bottom) card, centers the question title properly
- **HomeView**: Sparklines now inline with list name instead of on a second line; Prioritise button styling simplified

## Changes

**PairwiseView:**
- `···` overflow menu (trailing toolbar) replaces "Done for now" button in header; undo also moved there
- Header question title now truly centered with "N left" as a `.overlay(alignment: .trailing)`
- Removed "Tap to pick" hint + `hand.tap` icon from top card
- Removed "Top one" / "This one" explicit choice buttons (cards are already tappable/swipeable)
- Removed "Swipe to choose" static hint
- Removed "Skip" button — it was identical to "About equal" (`skip()` calls `equal()`)
- "About equal" is now a centered, natural-width secondary button
- Bottom card gets a `Color.blue.opacity(0.3)` border stroke to signal it's the active/interactive card
- Top card border softened to `Color(.separator).opacity(0.3)`

**HomeView:**
- `CollapsedListHeader`: sparkline moved inline into the same `HStack` as the list name dot + title
- List name gets `.lineLimit(1)` so it truncates rather than wrapping
- Sparkline gets `.fixedSize(horizontal: true, vertical: false)` to keep capsule widths stable
- Prioritise button: removed conflicting `.buttonStyle(.borderedProminent)` + `.controlSize(.large)` + `.tint()` — replaced with `.buttonStyle(.plain)` to let the manual background/foreground/clipShape styling work cleanly

## Test plan

- [ ] Build on iOS 26 simulator
- [ ] Start a prioritise session: confirm no "Top one"/"This one" buttons, no "Swipe to choose" hint, no "Tap to pick" on top card
- [ ] Tap top card → picks it; tap/swipe bottom card → picks it
- [ ] `···` menu shows "Undo" (when available) and "Done for now"; both work correctly
- [ ] Bottom card has a visible blue border; top card has a subtle neutral border
- [ ] "About equal" button works (ranks as tie)
- [ ] HomeView list rows: sparkline appears inline to the right of the list name
- [ ] Long list names truncate cleanly without pushing sparkline off-screen
- [ ] Prioritise button renders correctly in both selected and unselected states

Deferred: two-finger multi-select → jwbsmall/Retinder#92

🤖 Generated with [Claude Code](https://claude.com/claude-code)