### PR TITLE
Fix issues #72, #70, #69, #92

### DIFF
--- a/Sources/PairwiseReminders/Models/PairwiseSession.swift
+++ b/Sources/PairwiseReminders/Models/PairwiseSession.swift
@@ -129,6 +129,23 @@ final class PairwiseSession: ObservableObject {
         }
     }
 
+    // MARK: - Due-date Defaults
+
+    var defaultHighDueTarget: DueTarget {
+        get { DueTarget(rawValue: UserDefaults.standard.string(forKey: "due_default_high") ?? "") ?? .today }
+        set { UserDefaults.standard.set(newValue.rawValue, forKey: "due_default_high") }
+    }
+
+    var defaultMediumDueTarget: DueTarget {
+        get { DueTarget(rawValue: UserDefaults.standard.string(forKey: "due_default_medium") ?? "") ?? .tomorrow }
+        set { UserDefaults.standard.set(newValue.rawValue, forKey: "due_default_medium") }
+    }
+
+    var defaultLowDueTarget: DueTarget {
+        get { DueTarget(rawValue: UserDefaults.standard.string(forKey: "due_default_low") ?? "") ?? .nextWeek }
+        set { UserDefaults.standard.set(newValue.rawValue, forKey: "due_default_low") }
+    }
+
     // MARK: - Starting a Session
 
     /// Begins a session for the given lists. Fetches items, runs AI seeding, then

--- a/Sources/PairwiseReminders/Services/RemindersManager.swift
+++ b/Sources/PairwiseReminders/Services/RemindersManager.swift
@@ -197,7 +197,14 @@ final class RemindersManager: ObservableObject {
 
     /// Sets the due date for the top `count` ranked items, then commits.
     /// When `includeTime` is true, preserves the time component from `dueDate`.
-    func applyDueDates(_ items: [ReminderItem], count: Int, dueDate: Date, includeTime: Bool = false) throws {
+    /// When `addAlarms` is true, attaches an EKAlarm at the due date to each affected item.
+    func applyDueDates(
+        _ items: [ReminderItem],
+        count: Int,
+        dueDate: Date,
+        includeTime: Bool = false,
+        addAlarms: Bool = false
+    ) throws {
         guard !items.isEmpty else { return }
         let n = min(count, items.count)
         let fields: Set<Calendar.Component> = includeTime
@@ -207,10 +214,45 @@ final class RemindersManager: ObservableObject {
         for (index, item) in items.enumerated() {
             if index < n {
                 item.ekReminder.dueDateComponents = components
+                if addAlarms {
+                    removeExistingRelativeAlarms(from: item.ekReminder)
+                    item.ekReminder.addAlarm(EKAlarm(relativeOffset: 0))
+                }
             }
             try store.save(item.ekReminder, commit: false)
         }
         try store.commit()
+    }
+
+    /// Assigns per-item due dates from explicit (item, date) pairs, then commits.
+    /// Used in tiered priority mode where each tier has its own date target.
+    /// When `addAlarms` is true, attaches an EKAlarm at the due date to each item.
+    func applyTieredDueDates(
+        _ assignments: [(ReminderItem, Date)],
+        includeTime: Bool = false,
+        addAlarms: Bool = false
+    ) throws {
+        guard !assignments.isEmpty else { return }
+        let fields: Set<Calendar.Component> = includeTime
+            ? [.year, .month, .day, .hour, .minute]
+            : [.year, .month, .day]
+        for (item, date) in assignments {
+            item.ekReminder.dueDateComponents = Calendar.current.dateComponents(fields, from: date)
+            if addAlarms {
+                removeExistingRelativeAlarms(from: item.ekReminder)
+                item.ekReminder.addAlarm(EKAlarm(relativeOffset: 0))
+            }
+            try store.save(item.ekReminder, commit: false)
+        }
+        try store.commit()
+    }
+
+    /// Removes any zero-offset relative alarms previously added by Retinder, to avoid duplicates.
+    private func removeExistingRelativeAlarms(from reminder: EKReminder) {
+        guard let alarms = reminder.alarms else { return }
+        for alarm in alarms where alarm.absoluteDate == nil && alarm.relativeOffset == 0 {
+            reminder.removeAlarm(alarm)
+        }
     }
 
     /// Marks the top `count` items as High priority and the rest as None, then commits.

--- a/Sources/PairwiseReminders/Views/HomeView.swift
+++ b/Sources/PairwiseReminders/Views/HomeView.swift
@@ -38,10 +38,12 @@ struct HomeView: View {
 
     @State private var expandedListIDs: Set<String> = []
     @State private var selectedListIDs: Set<String> = []
-    @State private var selectedItemIDs: Set<String> = []
-    @State private var isSelecting: Bool = false
+    @State private var itemSelection: Set<String> = []  // item IDs bound to List(selection:)
+    @State private var editMode: EditMode = .inactive
     @State private var itemsByList: [String: [ReminderItem]] = [:]
     @State private var loadingListIDs: Set<String> = []
+
+    private var isSelecting: Bool { editMode == .active }
 
     @State private var groupingMode: GroupingMode = {
         GroupingMode(rawValue: UserDefaults.standard.string(forKey: "grouping_mode") ?? "") ?? .byList
@@ -120,9 +122,9 @@ struct HomeView: View {
                 ToolbarItem(placement: .navigationBarLeading) {
                     if isSelecting {
                         Button("Cancel") {
-                            isSelecting = false
+                            editMode = .inactive
                             selectedListIDs = []
-                            selectedItemIDs = []
+                            itemSelection = []
                         }
                         .font(.subheadline)
                     } else if groupingMode == .byList {
@@ -151,8 +153,13 @@ struct HomeView: View {
                             }
                         }
                         Button(isSelecting ? "Done" : "Select") {
-                            isSelecting.toggle()
-                            if !isSelecting { selectedListIDs = []; selectedItemIDs = [] }
+                            if editMode == .active {
+                                editMode = .inactive
+                                selectedListIDs = []
+                                itemSelection = []
+                            } else {
+                                editMode = .active
+                            }
                         }
                         .font(.subheadline.weight(isSelecting ? .semibold : .regular))
                     }
@@ -171,12 +178,12 @@ struct HomeView: View {
                 PrioritiseOptionsSheet(selectionLabel: prioritiseLabel) {
                     showPrioritiseOptions = false
                     showPrioritise = true
-                    isSelecting = false
-                    if !selectedItemIDs.isEmpty {
+                    editMode = .inactive
+                    if !itemSelection.isEmpty {
                         // Item-level selection: pass pre-loaded items directly.
-                        let ids = selectedItemIDs
+                        let ids = itemSelection
                         let items = itemsByList.values.flatMap { $0 }.filter { ids.contains($0.id) }
-                        selectedItemIDs = []
+                        itemSelection = []
                         Task {
                             await session.start(
                                 items: items,
@@ -239,25 +246,38 @@ struct HomeView: View {
     // MARK: - List Content (by list)
 
     private var listContent: some View {
-        List {
+        List(selection: $itemSelection) {
             ForEach(remindersManager.lists, id: \.calendarIdentifier) { calendar in
                 let id = calendar.calendarIdentifier
                 let listRecords = records(for: calendar)
 
-                DisclosureGroup(isExpanded: expandBinding(for: id)) {
-                    expandedContent(for: id, calendar: calendar, records: listRecords)
-                } label: {
-                    CollapsedListHeader(
-                        calendar: calendar,
-                        records: listRecords,
-                        isSelected: selectedListIDs.contains(id),
-                        isSelecting: isSelecting,
-                        onToggleSelect: { toggleSelect(id) }
-                    )
+                Section {
+                    if expandedListIDs.contains(id) {
+                        expandedContent(for: id, calendar: calendar, records: listRecords)
+                    }
+                } header: {
+                    Button {
+                        if expandedListIDs.contains(id) {
+                            expandedListIDs.remove(id)
+                        } else {
+                            expandedListIDs.insert(id)
+                            loadItemsIfNeeded(for: id)
+                        }
+                    } label: {
+                        CollapsedListHeader(
+                            calendar: calendar,
+                            records: listRecords,
+                            isSelected: selectedListIDs.contains(id),
+                            isSelecting: isSelecting,
+                            onToggleSelect: { toggleSelect(id) }
+                        )
+                    }
+                    .buttonStyle(.plain)
                 }
             }
         }
         .listStyle(.insetGrouped)
+        .environment(\.editMode, $editMode)
     }
 
     @ViewBuilder
@@ -285,24 +305,22 @@ struct HomeView: View {
                     .listRowBackground(Color.clear)
             } else {
                 ForEach(Array(ranked.enumerated()), id: \.element.id) { index, item in
-                    ExpandedItemRow(
-                        item: item, rank: index + 1, eloMin: eloMin, eloMax: eloMax,
-                        isSelecting: isSelecting, isSelected: selectedItemIDs.contains(item.id)
-                    )
-                    .contentShape(Rectangle())
-                    .onTapGesture {
-                        if isSelecting { toggleItemSelect(item.id) } else { selectedList = calendar }
-                    }
+                    ExpandedItemRow(item: item, rank: index + 1, eloMin: eloMin, eloMax: eloMax)
+                        .tag(item.id)
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            guard editMode == .inactive else { return }
+                            selectedList = calendar
+                        }
                 }
                 ForEach(unranked, id: \.id) { item in
-                    ExpandedItemRow(
-                        item: item, rank: nil, eloMin: eloMin, eloMax: eloMax,
-                        isSelecting: isSelecting, isSelected: selectedItemIDs.contains(item.id)
-                    )
-                    .contentShape(Rectangle())
-                    .onTapGesture {
-                        if isSelecting { toggleItemSelect(item.id) } else { selectedList = calendar }
-                    }
+                    ExpandedItemRow(item: item, rank: nil, eloMin: eloMin, eloMax: eloMax)
+                        .tag(item.id)
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            guard editMode == .inactive else { return }
+                            selectedList = calendar
+                        }
                 }
             }
         }
@@ -311,7 +329,7 @@ struct HomeView: View {
     // MARK: - Flat Content (all reminders sorted by Elo)
 
     private var flatContent: some View {
-        List {
+        List(selection: $itemSelection) {
             if allItems.isEmpty {
                 Text("No incomplete reminders")
                     .font(.caption)
@@ -323,48 +341,41 @@ struct HomeView: View {
                     ExpandedItemRow(
                         item: item, rank: index + 1,
                         eloMin: globalEloMin, eloMax: globalEloMax,
-                        showListName: true,
-                        isSelecting: isSelecting,
-                        isSelected: selectedItemIDs.contains(item.id)
+                        showListName: true
                     )
+                    .tag(item.id)
                     .contentShape(Rectangle())
                     .onTapGesture {
-                        if isSelecting {
-                            toggleItemSelect(item.id)
-                        } else {
-                            selectedList = remindersManager.lists
-                                .first { $0.calendarIdentifier == item.ekReminder.calendar?.calendarIdentifier }
-                        }
+                        guard editMode == .inactive else { return }
+                        selectedList = remindersManager.lists
+                            .first { $0.calendarIdentifier == item.ekReminder.calendar?.calendarIdentifier }
                     }
                 }
                 ForEach(unranked, id: \.id) { item in
                     ExpandedItemRow(
                         item: item, rank: nil,
                         eloMin: globalEloMin, eloMax: globalEloMax,
-                        showListName: true,
-                        isSelecting: isSelecting,
-                        isSelected: selectedItemIDs.contains(item.id)
+                        showListName: true
                     )
+                    .tag(item.id)
                     .contentShape(Rectangle())
                     .onTapGesture {
-                        if isSelecting {
-                            toggleItemSelect(item.id)
-                        } else {
-                            selectedList = remindersManager.lists
-                                .first { $0.calendarIdentifier == item.ekReminder.calendar?.calendarIdentifier }
-                        }
+                        guard editMode == .inactive else { return }
+                        selectedList = remindersManager.lists
+                            .first { $0.calendarIdentifier == item.ekReminder.calendar?.calendarIdentifier }
                     }
                 }
             }
         }
         .listStyle(.plain)
+        .environment(\.editMode, $editMode)
         .task { loadAllItemsIfNeeded() }
     }
 
     // MARK: - Due Date Content (sections by date bucket)
 
     private var dueDateContent: some View {
-        List {
+        List(selection: $itemSelection) {
             if allItems.isEmpty {
                 Text("No incomplete reminders")
                     .font(.caption)
@@ -374,41 +385,32 @@ struct HomeView: View {
                     Section(section.id) {
                         let ranked = section.items.filter { $0.comparisonCount > 0 }
                         let unranked = section.items.filter { $0.comparisonCount == 0 }
-                        // Rank within this section for display purposes
-                        ForEach(Array(ranked.enumerated()), id: \.element.id) { index, item in
+                        ForEach(ranked, id: \.id) { item in
                             ExpandedItemRow(
                                 item: item, rank: nil,
                                 eloMin: globalEloMin, eloMax: globalEloMax,
-                                showListName: true,
-                                isSelecting: isSelecting,
-                                isSelected: selectedItemIDs.contains(item.id)
+                                showListName: true
                             )
+                            .tag(item.id)
                             .contentShape(Rectangle())
                             .onTapGesture {
-                                if isSelecting {
-                                    toggleItemSelect(item.id)
-                                } else {
-                                    selectedList = remindersManager.lists
-                                        .first { $0.calendarIdentifier == item.ekReminder.calendar?.calendarIdentifier }
-                                }
+                                guard editMode == .inactive else { return }
+                                selectedList = remindersManager.lists
+                                    .first { $0.calendarIdentifier == item.ekReminder.calendar?.calendarIdentifier }
                             }
                         }
                         ForEach(unranked, id: \.id) { item in
                             ExpandedItemRow(
                                 item: item, rank: nil,
                                 eloMin: globalEloMin, eloMax: globalEloMax,
-                                showListName: true,
-                                isSelecting: isSelecting,
-                                isSelected: selectedItemIDs.contains(item.id)
+                                showListName: true
                             )
+                            .tag(item.id)
                             .contentShape(Rectangle())
                             .onTapGesture {
-                                if isSelecting {
-                                    toggleItemSelect(item.id)
-                                } else {
-                                    selectedList = remindersManager.lists
-                                        .first { $0.calendarIdentifier == item.ekReminder.calendar?.calendarIdentifier }
-                                }
+                                guard editMode == .inactive else { return }
+                                selectedList = remindersManager.lists
+                                    .first { $0.calendarIdentifier == item.ekReminder.calendar?.calendarIdentifier }
                             }
                         }
                     }
@@ -416,19 +418,20 @@ struct HomeView: View {
             }
         }
         .listStyle(.insetGrouped)
+        .environment(\.editMode, $editMode)
         .task { loadAllItemsIfNeeded() }
     }
 
     // MARK: - Prioritise Button
 
-    private var hasSelection: Bool { !selectedListIDs.isEmpty || !selectedItemIDs.isEmpty }
+    private var hasSelection: Bool { !selectedListIDs.isEmpty || !itemSelection.isEmpty }
 
     private var prioritiseButton: some View {
         VStack(spacing: 0) {
             Button {
                 if !hasSelection {
                     // Shortcut: tapping the button starts selection mode
-                    isSelecting = true
+                    editMode = .active
                 } else {
                     showPrioritiseOptions = true
                 }
@@ -449,8 +452,8 @@ struct HomeView: View {
     }
 
     private var prioritiseLabel: String {
-        if !selectedItemIDs.isEmpty {
-            let n = selectedItemIDs.count
+        if !itemSelection.isEmpty {
+            let n = itemSelection.count
             return "Prioritise \(n == 1 ? "1 Item" : "\(n) Items")"
         }
         if !selectedListIDs.isEmpty {
@@ -489,28 +492,6 @@ struct HomeView: View {
         } else {
             selectedListIDs.insert(id)
         }
-    }
-
-    private func toggleItemSelect(_ id: String) {
-        if selectedItemIDs.contains(id) {
-            selectedItemIDs.remove(id)
-        } else {
-            selectedItemIDs.insert(id)
-        }
-    }
-
-    private func expandBinding(for id: String) -> Binding<Bool> {
-        Binding(
-            get: { expandedListIDs.contains(id) },
-            set: { expanding in
-                if expanding {
-                    expandedListIDs.insert(id)
-                    loadItemsIfNeeded(for: id)
-                } else {
-                    expandedListIDs.remove(id)
-                }
-            }
-        )
     }
 
     private func loadItemsIfNeeded(for id: String) {

--- a/Sources/PairwiseReminders/Views/ListDetailView.swift
+++ b/Sources/PairwiseReminders/Views/ListDetailView.swift
@@ -200,12 +200,34 @@ struct ListDetailView: View {
                 }
             }
             if options.applyDueDates {
-                try remindersManager.applyDueDates(
-                    items,
-                    count: options.dueDateCount,
-                    dueDate: options.resolvedDueDate,
-                    includeTime: options.includeTime
-                )
+                if options.applyPriorities && options.priorityMode == .tiered {
+                    let high   = min(options.highCount,   items.count)
+                    let medium = min(options.mediumCount, items.count - high)
+                    let low    = min(options.lowCount,    items.count - high - medium)
+                    var assignments: [(ReminderItem, Date)] = []
+                    for i in 0..<high {
+                        assignments.append((items[i], options.resolvedDate(for: options.highDueTarget,   custom: options.highCustomDate)))
+                    }
+                    for i in high..<(high + medium) {
+                        assignments.append((items[i], options.resolvedDate(for: options.mediumDueTarget, custom: options.mediumCustomDate)))
+                    }
+                    for i in (high + medium)..<(high + medium + low) {
+                        assignments.append((items[i], options.resolvedDate(for: options.lowDueTarget,    custom: options.lowCustomDate)))
+                    }
+                    try remindersManager.applyTieredDueDates(
+                        assignments,
+                        includeTime: options.includeTime,
+                        addAlarms: options.addAlarms
+                    )
+                } else {
+                    try remindersManager.applyDueDates(
+                        items,
+                        count: options.dueDateCount,
+                        dueDate: options.resolvedDueDate,
+                        includeTime: options.includeTime,
+                        addAlarms: options.addAlarms
+                    )
+                }
             }
             if options.applyFlags {
                 try remindersManager.applyFlags(items, count: options.flagCount)

--- a/Sources/PairwiseReminders/Views/ResultsView.swift
+++ b/Sources/PairwiseReminders/Views/ResultsView.swift
@@ -147,12 +147,34 @@ struct ResultsView: View {
                 }
             }
             if options.applyDueDates {
-                try remindersManager.applyDueDates(
-                    items,
-                    count: options.dueDateCount,
-                    dueDate: options.resolvedDueDate,
-                    includeTime: options.includeTime
-                )
+                if options.applyPriorities && options.priorityMode == .tiered {
+                    let high   = min(options.highCount,   items.count)
+                    let medium = min(options.mediumCount, items.count - high)
+                    let low    = min(options.lowCount,    items.count - high - medium)
+                    var assignments: [(ReminderItem, Date)] = []
+                    for i in 0..<high {
+                        assignments.append((items[i], options.resolvedDate(for: options.highDueTarget,   custom: options.highCustomDate)))
+                    }
+                    for i in high..<(high + medium) {
+                        assignments.append((items[i], options.resolvedDate(for: options.mediumDueTarget, custom: options.mediumCustomDate)))
+                    }
+                    for i in (high + medium)..<(high + medium + low) {
+                        assignments.append((items[i], options.resolvedDate(for: options.lowDueTarget,    custom: options.lowCustomDate)))
+                    }
+                    try remindersManager.applyTieredDueDates(
+                        assignments,
+                        includeTime: options.includeTime,
+                        addAlarms: options.addAlarms
+                    )
+                } else {
+                    try remindersManager.applyDueDates(
+                        items,
+                        count: options.dueDateCount,
+                        dueDate: options.resolvedDueDate,
+                        includeTime: options.includeTime,
+                        addAlarms: options.addAlarms
+                    )
+                }
             }
             if options.applyFlags {
                 try remindersManager.applyFlags(items, count: options.flagCount)
@@ -236,6 +258,24 @@ private struct SessionRankedRow: View {
     }
 }
 
+// MARK: - Due Date Target (top-level for use in ApplyOptions + PairwiseSession defaults)
+
+enum DueTarget: String, CaseIterable {
+    case today    = "today"
+    case tomorrow = "tomorrow"
+    case nextWeek = "next_week"
+    case custom   = "custom"
+
+    var displayName: String {
+        switch self {
+        case .today:    return "Today"
+        case .tomorrow: return "Tomorrow"
+        case .nextWeek: return "Next week"
+        case .custom:   return "Custom…"
+        }
+    }
+}
+
 // MARK: - Apply Options (shared with ListDetailView)
 
 struct ApplyOptions {
@@ -253,6 +293,7 @@ struct ApplyOptions {
 
     // MARK: Due Dates
     var applyDueDates: Bool = false
+    /// Count used in topN / priorities-off path.
     var dueDateCount: Int = 3
     var dueTarget: DueTarget = .today
     var customDate: Date = .now
@@ -261,19 +302,29 @@ struct ApplyOptions {
         bySettingHour: 9, minute: 0, second: 0, of: .now
     ) ?? .now
 
+    // Per-tier due dates — used when priorityMode == .tiered && applyPriorities == true.
+    var highDueTarget: DueTarget = .today
+    var mediumDueTarget: DueTarget = .tomorrow
+    var lowDueTarget: DueTarget = .nextWeek
+    var highCustomDate: Date = .now
+    var mediumCustomDate: Date = .now
+    var lowCustomDate: Date = .now
+
+    /// When true, adds an EKAlarm at the due date on each item that receives a date.
+    var addAlarms: Bool = false
+
     /// Calendar identifiers whose items should be skipped during write-back.
     var excludedListIDs: Set<String> = []
 
-    enum DueTarget { case today, tomorrow, nextWeek, custom }
-
-    var resolvedDueDate: Date {
+    /// Resolves a DueTarget to a concrete Date, sharing the time settings when `includeTime` is on.
+    func resolvedDate(for target: DueTarget, custom: Date) -> Date {
         let cal = Calendar.current
         let dayStart: Date
-        switch dueTarget {
+        switch target {
         case .today:    dayStart = cal.startOfDay(for: .now)
         case .tomorrow: dayStart = cal.date(byAdding: .day, value: 1, to: cal.startOfDay(for: .now)) ?? .now
         case .nextWeek: dayStart = cal.date(byAdding: .weekOfYear, value: 1, to: cal.startOfDay(for: .now)) ?? .now
-        case .custom:   dayStart = cal.startOfDay(for: customDate)
+        case .custom:   dayStart = cal.startOfDay(for: custom)
         }
         guard includeTime else { return dayStart }
         let timeComps = cal.dateComponents([.hour, .minute], from: dueTime)
@@ -281,6 +332,8 @@ struct ApplyOptions {
                         minute: timeComps.minute ?? 0,
                         second: 0, of: dayStart) ?? dayStart
     }
+
+    var resolvedDueDate: Date { resolvedDate(for: dueTarget, custom: customDate) }
 
     // MARK: Flags
     var applyFlags: Bool = false
@@ -296,8 +349,14 @@ struct ApplySheet: View {
 
     @State private var options = ApplyOptions()
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var session: PairwiseSession
 
     var itemCount: Int { items.count }
+
+    /// True when the due dates section should show per-tier pickers rather than a single date.
+    private var useTieredDates: Bool {
+        options.applyPriorities && options.priorityMode == .tiered
+    }
 
     /// Distinct lists (calendar ID → name + color) present in the ranked items.
     private var distinctLists: [(id: String, name: String, color: CGColor)] {
@@ -350,6 +409,11 @@ struct ApplySheet: View {
                 dueDatesSection
                 flagsSection
             }
+            .onAppear {
+                options.highDueTarget   = session.defaultHighDueTarget
+                options.mediumDueTarget = session.defaultMediumDueTarget
+                options.lowDueTarget    = session.defaultLowDueTarget
+            }
             .navigationTitle("Apply to Reminders")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -390,14 +454,9 @@ struct ApplySheet: View {
                     Stepper("Low: \(options.lowCount)", value: $options.lowCount,
                             in: 0...max(0, itemCount - options.highCount - options.mediumCount))
                     let noneCount = max(0, itemCount - options.highCount - options.mediumCount - options.lowCount)
-                    HStack {
-                        Text("None (remainder)")
-                            .foregroundStyle(.secondary)
-                        Spacer()
-                        Text("\(noneCount)")
-                            .foregroundStyle(.secondary)
-                            .monospacedDigit()
-                    }
+                    LabeledContent("None (remainder)", value: "\(noneCount)")
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
                 }
             }
         } header: {
@@ -413,39 +472,65 @@ struct ApplySheet: View {
         Section {
             Toggle("Set due dates", isOn: $options.applyDueDates)
             if options.applyDueDates {
-                Stepper(
-                    "Top \(options.dueDateCount) item\(options.dueDateCount == 1 ? "" : "s")",
-                    value: $options.dueDateCount,
-                    in: 1...max(1, itemCount)
-                )
-                Picker("Due", selection: $options.dueTarget) {
-                    Text("Today").tag(ApplyOptions.DueTarget.today)
-                    Text("Tomorrow").tag(ApplyOptions.DueTarget.tomorrow)
-                    Text("Next week").tag(ApplyOptions.DueTarget.nextWeek)
-                    Text("Custom…").tag(ApplyOptions.DueTarget.custom)
-                }
-                if options.dueTarget == .custom {
-                    DatePicker("Date", selection: $options.customDate,
-                               in: Date.now...,
-                               displayedComponents: options.includeTime ? [.date, .hourAndMinute] : .date)
+                if useTieredDates {
+                    // Per-tier date pickers — counts are inherited from the Priorities section.
+                    tierDuePicker(label: "High",   target: $options.highDueTarget,   custom: $options.highCustomDate)
+                    tierDuePicker(label: "Medium", target: $options.mediumDueTarget, custom: $options.mediumCustomDate)
+                    tierDuePicker(label: "Low",    target: $options.lowDueTarget,    custom: $options.lowCustomDate)
+                } else {
+                    Stepper(
+                        "Top \(options.dueDateCount) item\(options.dueDateCount == 1 ? "" : "s")",
+                        value: $options.dueDateCount,
+                        in: 1...max(1, itemCount)
+                    )
+                    Picker("Due", selection: $options.dueTarget) {
+                        ForEach(DueTarget.allCases, id: \.self) { t in
+                            Text(t.displayName).tag(t)
+                        }
+                    }
+                    if options.dueTarget == .custom {
+                        DatePicker("Date", selection: $options.customDate,
+                                   in: Date.now...,
+                                   displayedComponents: options.includeTime ? [.date, .hourAndMinute] : .date)
+                    }
                 }
                 Toggle("Set time", isOn: $options.includeTime)
-                if options.includeTime && options.dueTarget != .custom {
+                if options.includeTime && !useTieredDates && options.dueTarget != .custom {
                     DatePicker("Time", selection: $options.dueTime,
                                displayedComponents: .hourAndMinute)
                 }
+                Toggle("Add reminder alert", isOn: $options.addAlarms)
             }
         } header: {
             Text("Due Dates")
         } footer: {
             if options.applyDueDates {
-                let n = options.dueDateCount
-                if options.includeTime {
-                    Text("Sets date + time on the top \(n) item\(n == 1 ? "" : "s").")
+                if useTieredDates {
+                    Text("Each priority tier receives its own due date. A reminder alert fires at that time for each item.")
+                        .opacity(options.addAlarms ? 1 : 0)
                 } else {
-                    Text("Sets date (no time) on the top \(n) item\(n == 1 ? "" : "s").")
+                    let n = options.dueDateCount
+                    Text("Sets date\(options.includeTime ? " + time" : "") on the top \(n) item\(n == 1 ? "" : "s").")
                 }
             }
+        }
+    }
+
+    @ViewBuilder
+    private func tierDuePicker(
+        label: String,
+        target: Binding<DueTarget>,
+        custom: Binding<Date>
+    ) -> some View {
+        Picker(label, selection: target) {
+            ForEach(DueTarget.allCases, id: \.self) { t in
+                Text(t.displayName).tag(t)
+            }
+        }
+        if target.wrappedValue == .custom {
+            DatePicker("Date (\(label))", selection: custom,
+                       in: Date.now...,
+                       displayedComponents: options.includeTime ? [.date, .hourAndMinute] : .date)
         }
     }
 

--- a/Sources/PairwiseReminders/Views/SettingsView.swift
+++ b/Sources/PairwiseReminders/Views/SettingsView.swift
@@ -1,7 +1,9 @@
 import SwiftUI
 
-/// Settings tab: AI configuration.
+/// Settings tab: AI configuration and apply-sheet defaults.
 struct SettingsView: View {
+
+    @EnvironmentObject private var session: PairwiseSession
 
     @State private var apiKey: String = ""
     @State private var apiKeyMasked = true
@@ -16,6 +18,7 @@ struct SettingsView: View {
         NavigationStack {
             Form {
                 aiSection
+                dueDateDefaultsSection
             }
             .navigationTitle("Settings")
             .onAppear { loadSettings() }
@@ -89,6 +92,41 @@ struct SettingsView: View {
                 .foregroundStyle(.red)
                 .font(.caption)
                 .lineLimit(2)
+        }
+    }
+
+    // MARK: - Due-date Defaults Section
+
+    private var dueDateDefaultsSection: some View {
+        Section {
+            Picker("High priority", selection: Binding(
+                get: { session.defaultHighDueTarget },
+                set: { session.defaultHighDueTarget = $0 }
+            )) {
+                ForEach(DueTarget.allCases.filter { $0 != .custom }, id: \.self) { t in
+                    Text(t.displayName).tag(t)
+                }
+            }
+            Picker("Medium priority", selection: Binding(
+                get: { session.defaultMediumDueTarget },
+                set: { session.defaultMediumDueTarget = $0 }
+            )) {
+                ForEach(DueTarget.allCases.filter { $0 != .custom }, id: \.self) { t in
+                    Text(t.displayName).tag(t)
+                }
+            }
+            Picker("Low priority", selection: Binding(
+                get: { session.defaultLowDueTarget },
+                set: { session.defaultLowDueTarget = $0 }
+            )) {
+                ForEach(DueTarget.allCases.filter { $0 != .custom }, id: \.self) { t in
+                    Text(t.displayName).tag(t)
+                }
+            }
+        } header: {
+            Text("Due-date defaults")
+        } footer: {
+            Text("Default dates used when applying tiered priorities with due dates in the Apply sheet.")
         }
     }
 


### PR DESCRIPTION
Closes #72, closes #70, closes #69, closes #92.

## Summary

### Apply sheet

- **#72** — "None (remainder)" count now renders inline with the High/Medium/Low Stepper rows as a `LabeledContent` row (matching visual weight and alignment).

- **#69** — Per-tier due dates: when priority mode is Tiered, the Due Dates section shows three separate date pickers (High/Medium/Low) instead of a single date with a count stepper. Tier date defaults (Today/Tomorrow/Next week) are stored in UserDefaults via `PairwiseSession` and configurable in Settings → "Due-date defaults". `ApplySheet` seeds the tier targets from these defaults on appear.

- **#70** — "Add reminder alert" toggle in Due Dates section. When enabled, an `EKAlarm(relativeOffset: 0)` is attached to each reminder that receives a due date — firing a system Reminders notification at the due time. Uses the existing Reminders permission. No `UNUserNotificationCenter` or new entitlements needed. A `removeExistingRelativeAlarms()` guard prevents duplicates on re-apply.

### HomeView

- **#92** — Native two-finger drag multi-select: replaced `DisclosureGroup` in byList mode with a manual `Section + Button` header so `List(selection:)` works (DisclosureGroup conflicts with it). All three grouping modes (byList/flat/byDueDate) now use `List(selection: $itemSelection)` + `.environment(\.editMode, $editMode)`. Two-finger drag across item rows enters selection mode and selects items via iOS's built-in gesture — no UIKit bridge needed. Existing list-level selection (whole lists via CollapsedListHeader checkmark) is preserved. Expand/collapse still works via the Section header Button.

## Test plan

- [ ] **#72**: Open Apply sheet, enable Tiered priorities → "None (remainder)" row is visually inline with High/Medium/Low Steppers (label left, count right, same height).
- [ ] **#69**: In Tiered priority mode with due dates enabled, confirm three tier date Pickers appear. Set one to Custom and verify a DatePicker appears beneath. Change defaults in Settings → Due-date defaults and reopen the sheet — defaults load correctly.
- [ ] **#70**: Enable "Add reminder alert" and Apply. Open iOS Reminders — the items show a bell/alert indicator. Set a due date 1 min in the future and verify a notification fires.
- [ ] **#92**: Two-finger drag across rows on the HomeView list (all three grouping modes) — items get selected. Tap Select/Done toolbar button to toggle edit mode. Expand/collapse of byList sections works (tap header). Prioritise button label counts match selection.
- [ ] Build succeeds with no warnings on iOS 26 simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)