### PR TITLE
Fix AI seeding hang + surface errors

### DIFF
--- a/Sources/PairwiseReminders/Models/PairwiseSession.swift
+++ b/Sources/PairwiseReminders/Models/PairwiseSession.swift
@@ -248,7 +248,12 @@ final class PairwiseSession: ObservableObject {
         criteria: String?
     ) async -> [AnthropicService.SeededRank]? {
         guard FoundationModelService.isAvailable else { return nil }
-        return try? await FoundationModelService().seedRanking(summaries, criteria: criteria)
+        do {
+            return try await FoundationModelService().seedRanking(summaries, criteria: criteria)
+        } catch {
+            seedingError = "On-device: \(error.localizedDescription)"
+            return nil
+        }
     }
 
     private func tryAPISeeding(
@@ -256,7 +261,12 @@ final class PairwiseSession: ObservableObject {
         criteria: String?
     ) async -> [AnthropicService.SeededRank]? {
         guard let apiKey = KeychainService.load(), !apiKey.isEmpty else { return nil }
-        return try? await AnthropicService(apiKey: apiKey).seedRanking(summaries, criteria: criteria)
+        do {
+            return try await AnthropicService(apiKey: apiKey).seedRanking(summaries, criteria: criteria)
+        } catch {
+            seedingError = "API: \(error.localizedDescription)"
+            return nil
+        }
     }
 
     /// Maps AI seed ranks and confidence scores into initial Elo ratings and K-factors,

--- a/Sources/PairwiseReminders/Services/AnthropicService.swift
+++ b/Sources/PairwiseReminders/Services/AnthropicService.swift
@@ -187,7 +187,7 @@ struct AnthropicService {
     // MARK: - Private Helpers
 
     private func performRequest(body: [String: Any]) async throws -> Data {
-        var request = URLRequest(url: endpoint)
+        var request = URLRequest(url: endpoint, timeoutInterval: 30)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue(apiKey, forHTTPHeaderField: "x-api-key")

--- a/Sources/PairwiseReminders/Services/FoundationModelService.swift
+++ b/Sources/PairwiseReminders/Services/FoundationModelService.swift
@@ -24,8 +24,6 @@ struct FoundationModelService {
             throw FoundationModelError.modelUnavailable
         }
 
-        let modelSession = LanguageModelSession()
-
         let numberedList = summaries.enumerated().map { i, s in
             var line = "\(i + 1). [ID: \(s.id)] \(s.title)"
             if let notes = s.notes, !notes.isEmpty { line += " — \(notes)" }
@@ -47,9 +45,11 @@ struct FoundationModelService {
         \(numberedList)
         """
 
-        // Race the model response against a 10-second timeout to avoid hanging the seeding phase.
+        // Race the model response against a 10-second timeout. LanguageModelSession() is created
+        // inside the task so that model initialisation (which can block) is also covered.
         return try await withThrowingTaskGroup(of: [AnthropicService.SeededRank].self) { group in
             group.addTask {
+                let modelSession = LanguageModelSession()
                 let response = try await modelSession.respond(to: prompt)
                 return try self.parseResponse(response.content, summaries: summaries)
             }

--- a/Sources/PairwiseReminders/Views/FilteringView.swift
+++ b/Sources/PairwiseReminders/Views/FilteringView.swift
@@ -32,6 +32,14 @@ struct FilteringView: View {
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
                     .animation(.easeInOut(duration: 0.3), value: statusLine)
+
+                if let error = session.seedingError {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .multilineTextAlignment(.center)
+                        .padding(.top, 4)
+                }
             }
 
             ProgressView()


### PR DESCRIPTION
## Summary
- **FoundationModelService**: `LanguageModelSession()` was constructed *before* the `withThrowingTaskGroup`, so model init could hang indefinitely with no timeout. Moved inside the task so the 10s timeout covers it.
- **AnthropicService**: Added explicit `timeoutInterval: 30` to `URLRequest` — default was 60s, meaning a bad key/network could block for a minute.
- **PairwiseSession**: Both seeding paths now capture errors with `do/catch` instead of `try?`, setting `seedingError` with a message when they fail.
- **FilteringView**: Shows `session.seedingError` in orange below the status line so the user can see what went wrong instead of an indefinite spinner.

## Test plan
- [ ] On physical device with a valid API key: seeding should complete and show ranked items
- [ ] On physical device with invalid/missing key: error message appears in FilteringView within 30s, then advances to comparing with default Elo ratings
- [ ] On physical device with on-device AI preference: should either succeed within 10s or show a timeout error and fall back to API / default ratings
- [ ] Seeding with `aiPreference = .none`: skips directly to comparing, no error shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)