### PR TITLE
AI-only mode, pairwise top-N, AI evidence in results

### DIFF
--- a/Sources/PairwiseReminders/Models/PairwiseSession.swift
+++ b/Sources/PairwiseReminders/Models/PairwiseSession.swift
@@ -5,10 +5,9 @@ import SwiftData
 /// Session-level state for a single pairwise ranking run on one or more lists.
 ///
 /// Lifecycle:
-///   idle → seeding → comparing → done
+///   idle → seeding → (comparing →)? done
 ///
-/// `PrioritiseTab` observes this object to navigate between
-/// FilteringView → PairwiseView → ResultsView (session summary).
+/// For `.aiOnly` mode the comparing phase is skipped entirely.
 @MainActor
 final class PairwiseSession: ObservableObject {
 
@@ -44,20 +43,29 @@ final class PairwiseSession: ObservableObject {
     @Published private(set) var seedingFailed: Bool = false
     @Published var seedingError: String?
 
-    // MARK: - AI Preference
+    // MARK: - Mode
 
-    /// Which AI backend to prefer for seeding. Persisted via UserDefaults.
-    enum AIPreference: String, CaseIterable {
-        case api = "api"
-        case none = "none"
+    /// Session mode. Persisted via UserDefaults.
+    enum Mode: String, CaseIterable {
+        case aiOnly   = "ai_only"
+        case pairwise = "pairwise"
+        case both     = "both"
+
+        var displayName: String {
+            switch self {
+            case .aiOnly:   return "AI Only"
+            case .pairwise: return "Pairwise"
+            case .both:     return "Both"
+            }
+        }
     }
 
-    var aiPreference: AIPreference {
+    var mode: Mode {
         get {
-            AIPreference(rawValue: UserDefaults.standard.string(forKey: "ai_preference") ?? "") ?? .api
+            Mode(rawValue: UserDefaults.standard.string(forKey: "session_mode") ?? "") ?? .both
         }
         set {
-            UserDefaults.standard.set(newValue.rawValue, forKey: "ai_preference")
+            UserDefaults.standard.set(newValue.rawValue, forKey: "session_mode")
         }
     }
 
@@ -67,8 +75,10 @@ final class PairwiseSession: ObservableObject {
         set { UserDefaults.standard.set(newValue, forKey: "ai_criteria") }
     }
 
-    /// Limit comparisons to the top N AI-ranked items. Nil = no limit (all items).
-    var aiTopN: Int? {
+    /// Limit items to the top N. For AI modes, filtered by seed rank. For pairwise-only,
+    /// filtered by existing Elo (highest Elo = most prior evidence of importance).
+    /// Nil = no limit.
+    var topN: Int? {
         get {
             let v = UserDefaults.standard.integer(forKey: "ai_top_n")
             return v > 0 ? v : nil
@@ -101,8 +111,8 @@ final class PairwiseSession: ObservableObject {
 
     // MARK: - Starting a Session
 
-    /// Begins a session for the given lists. Fetches items, runs AI seeding, then
-    /// transitions to `.comparing`.
+    /// Begins a session for the given lists. Fetches items, runs AI seeding (unless pairwise-only),
+    /// then transitions to `.comparing` or `.done` depending on the mode.
     func start(
         listIDs: Set<String>,
         remindersManager: RemindersManager,
@@ -132,18 +142,7 @@ final class PairwiseSession: ObservableObject {
             return
         }
 
-        // 2. Attempt AI seeding to set initial Elo ratings.
-        await runSeeding(context: context)
-
-        // Guard: if the task was cancelled (e.g. user dismissed) while seeding, bail out cleanly.
-        guard !Task.isCancelled else {
-            phase = .idle
-            return
-        }
-
-        // 3. Start the Elo engine with (possibly seeded) items.
-        eloEngine.start(with: sessionItems)
-        phase = .comparing
+        await continueStart(eloEngine: eloEngine, context: context)
     }
 
     /// Begins a session for a specific pre-loaded set of items (individual selection path).
@@ -166,21 +165,30 @@ final class PairwiseSession: ObservableObject {
             return
         }
 
-        await runSeeding(context: context)
-
-        guard !Task.isCancelled else {
-            phase = .idle
-            return
-        }
-
-        eloEngine.start(with: sessionItems)
-        phase = .comparing
+        await continueStart(eloEngine: eloEngine, context: context)
     }
 
     /// Called by PairwiseView when the user taps "Done for now" or the engine converges.
     func finish(eloEngine: EloEngine, context: ModelContext) {
         rankedItems = eloEngine.finish(context: context)
         phase = .done
+    }
+
+    /// Reorders `rankedItems` in response to a user drag, updating persistent Elo ratings.
+    func reorderRankedItems(from source: IndexSet, to destination: Int, context: ModelContext) {
+        rankedItems.move(fromOffsets: source, toOffset: destination)
+
+        let allRecords = (try? context.fetch(FetchDescriptor<RankedItemRecord>())) ?? []
+        let recordsByID = Dictionary(uniqueKeysWithValues: allRecords.map { ($0.calendarItemIdentifier, $0) })
+
+        let spread = 20.0
+        let top = (rankedItems.first?.eloRating ?? 1000.0) + spread * Double(rankedItems.count)
+        for (i, item) in rankedItems.enumerated() {
+            let newRating = top - spread * Double(i)
+            rankedItems[i].eloRating = newRating
+            recordsByID[item.id]?.eloRating = newRating
+        }
+        try? context.save()
     }
 
     /// Resets all session state back to idle.
@@ -194,7 +202,38 @@ final class PairwiseSession: ObservableObject {
         seedingError = nil
     }
 
-    // MARK: - Private Seeding
+    // MARK: - Private
+
+    private func continueStart(eloEngine: EloEngine, context: ModelContext) async {
+        // For pairwise-only: apply top-N by prior Elo before starting.
+        if mode == .pairwise, let n = topN, n > 0, sessionItems.count > n {
+            sessionItems = Array(
+                sessionItems
+                    .sorted { $0.eloRating != $1.eloRating ? $0.eloRating > $1.eloRating : $0.title < $1.title }
+                    .prefix(n)
+            )
+        }
+
+        // Run AI seeding unless this is pairwise-only.
+        if mode != .pairwise {
+            await runSeeding(context: context)
+        }
+
+        guard !Task.isCancelled else {
+            phase = .idle
+            return
+        }
+
+        switch mode {
+        case .aiOnly:
+            // Skip pairwise — rank directly by seeded Elo.
+            rankedItems = sessionItems.sorted { $0.eloRating > $1.eloRating }
+            phase = .done
+        case .pairwise, .both:
+            eloEngine.start(with: sessionItems)
+            phase = .comparing
+        }
+    }
 
     private func runSeeding(context: ModelContext) async {
         let summaries = sessionItems.map { item in
@@ -207,14 +246,7 @@ final class PairwiseSession: ObservableObject {
         }
 
         let criteria = aiCriteria.isEmpty ? nil : aiCriteria
-        var seeds: [AnthropicService.SeededRank]?
-
-        switch aiPreference {
-        case .api:
-            seeds = await tryAPISeeding(summaries: summaries, criteria: criteria)
-        case .none:
-            break
-        }
+        let seeds = await tryAPISeeding(summaries: summaries, criteria: criteria)
 
         guard let seeds, !seeds.isEmpty else {
             seedingFailed = true
@@ -224,7 +256,7 @@ final class PairwiseSession: ObservableObject {
         applySeedRatings(seeds, context: context)
 
         // Truncate to top N if configured — only keep the highest-ranked items.
-        if let n = aiTopN, n > 0, sessionItems.count > n {
+        if let n = topN, n > 0, sessionItems.count > n {
             let topIDs = Set(seeds.sorted { $0.rank < $1.rank }.prefix(n).map(\.id))
             sessionItems = sessionItems.filter { topIDs.contains($0.id) }
         }
@@ -263,14 +295,18 @@ final class PairwiseSession: ObservableObject {
             // Lower confidence → higher K → easier for user to move this item.
             let k = max(8.0, 32.0 * (1.0 - Double(seed.confidence) / 100.0))
 
-            sessionItems[i].eloRating = elo
-            sessionItems[i].kFactor = k
+            sessionItems[i].eloRating   = elo
+            sessionItems[i].kFactor     = k
+            sessionItems[i].aiSeedRank  = seed.rank
+            sessionItems[i].aiConfidence = seed.confidence
+            sessionItems[i].aiReasoning = seed.reasoning
 
             if let record = recordByID[item.id] {
-                record.eloRating = elo
-                record.kFactor = k
-                record.aiSeedRank = seed.rank
+                record.eloRating   = elo
+                record.kFactor     = k
+                record.aiSeedRank  = seed.rank
                 record.aiConfidence = seed.confidence
+                record.aiReasoning  = seed.reasoning
             }
         }
         try? context.save()

--- a/Sources/PairwiseReminders/Models/RankedItemRecord.swift
+++ b/Sources/PairwiseReminders/Models/RankedItemRecord.swift
@@ -32,6 +32,9 @@ import SwiftData
     /// human comparison. Nil if no AI seeding has been performed.
     var aiConfidence: Int?
 
+    /// One-line reasoning from the AI explaining this item's rank.
+    var aiReasoning: String?
+
     init(
         calendarItemIdentifier: String,
         listCalendarIdentifier: String,

--- a/Sources/PairwiseReminders/Models/ReminderItem.swift
+++ b/Sources/PairwiseReminders/Models/ReminderItem.swift
@@ -15,6 +15,12 @@ struct ReminderItem: Identifiable, Equatable, @unchecked Sendable {
     /// Claude's one-line reasoning for why this item matters.
     var aiReasoning: String?
 
+    /// AI-suggested rank (1 = highest) from the most recent seeding pass.
+    var aiSeedRank: Int?
+
+    /// AI confidence in the seed rank, 0–100.
+    var aiConfidence: Int?
+
     /// Position in the final sorted order (0 = highest priority).
     var sortRank: Int?
 

--- a/Sources/PairwiseReminders/Services/AnthropicService.swift
+++ b/Sources/PairwiseReminders/Services/AnthropicService.swift
@@ -39,6 +39,7 @@ struct AnthropicService {
         let id: String
         let rank: Int
         let confidence: Int
+        let reasoning: String?
     }
 
     /// Sends reminder summaries to Claude and returns a full ranked ordering with
@@ -85,11 +86,12 @@ struct AnthropicService {
                         "items": [
                             "type": "object",
                             "properties": [
-                                "id":         ["type": "string", "description": "The item ID exactly as provided"],
+                                "id":         ["type": "string",  "description": "The item ID exactly as provided"],
                                 "rank":       ["type": "integer", "description": "1-based rank (1 = highest priority)"],
-                                "confidence": ["type": "integer", "description": "0–100 confidence in this rank"]
+                                "confidence": ["type": "integer", "description": "0–100 confidence in this rank"],
+                                "reasoning":  ["type": "string",  "description": "One sentence explaining why this item is ranked here"]
                             ],
-                            "required": ["id", "rank", "confidence"]
+                            "required": ["id", "rank", "confidence", "reasoning"]
                         ]
                     ]
                 ],
@@ -230,7 +232,12 @@ struct AnthropicService {
                 let rank = entry["rank"] as? Int,
                 let confidence = entry["confidence"] as? Int
             else { return nil }
-            return SeededRank(id: id, rank: rank, confidence: max(0, min(100, confidence)))
+            return SeededRank(
+                id: id,
+                rank: rank,
+                confidence: max(0, min(100, confidence)),
+                reasoning: entry["reasoning"] as? String
+            )
         }
     }
 

--- a/Sources/PairwiseReminders/Services/RemindersManager.swift
+++ b/Sources/PairwiseReminders/Services/RemindersManager.swift
@@ -81,12 +81,16 @@ final class RemindersManager: ObservableObject {
 
         return reminders.map { reminder in
             let record = recordsByID[reminder.calendarItemIdentifier]
-            return ReminderItem(
+            var item = ReminderItem(
                 from: reminder,
                 eloRating: record?.eloRating ?? 1000.0,
                 kFactor: record?.kFactor ?? 32.0,
                 comparisonCount: record?.comparisonCount ?? 0
             )
+            item.aiSeedRank  = record?.aiSeedRank
+            item.aiConfidence = record?.aiConfidence
+            item.aiReasoning  = record?.aiReasoning
+            return item
         }
     }
 

--- a/Sources/PairwiseReminders/Views/FilteringView.swift
+++ b/Sources/PairwiseReminders/Views/FilteringView.swift
@@ -58,7 +58,7 @@ struct FilteringView: View {
     private func updateStatus(count: Int) {
         if count == 0 {
             statusLine = "Fetching reminders…"
-        } else if session.aiPreference == .none {
+        } else if session.mode == .pairwise {
             statusLine = "Preparing \(count) item\(count == 1 ? "" : "s")…"
         } else {
             statusLine = "AI is ranking \(count) item\(count == 1 ? "" : "s")…"

--- a/Sources/PairwiseReminders/Views/HomeView.swift
+++ b/Sources/PairwiseReminders/Views/HomeView.swift
@@ -568,8 +568,7 @@ private struct PrioritiseFlow: View {
 
 // MARK: - Prioritise Options Sheet
 
-/// Pre-session configuration: AI seeding options.
-/// Tapping Start applies settings and triggers the session.
+/// Pre-session configuration: mode, AI criteria, and top-N limit.
 private struct PrioritiseOptionsSheet: View {
 
     let selectionLabel: String
@@ -578,7 +577,7 @@ private struct PrioritiseOptionsSheet: View {
     @EnvironmentObject private var session: PairwiseSession
     @Environment(\.dismiss) private var dismiss
 
-    @State private var useAI: Bool
+    @State private var mode: PairwiseSession.Mode
     @State private var criteria: String
     @State private var topNEnabled: Bool
     @State private var topN: Int
@@ -587,8 +586,8 @@ private struct PrioritiseOptionsSheet: View {
         self.selectionLabel = selectionLabel
         self.onStart = onStart
         let defaults = UserDefaults.standard
-        _useAI = State(initialValue:
-            (defaults.string(forKey: "ai_preference") ?? "") != PairwiseSession.AIPreference.none.rawValue
+        _mode = State(initialValue:
+            PairwiseSession.Mode(rawValue: defaults.string(forKey: "session_mode") ?? "") ?? .both
         )
         _criteria = State(initialValue: defaults.string(forKey: "ai_criteria") ?? "")
         let savedN = defaults.integer(forKey: "ai_top_n")
@@ -596,57 +595,69 @@ private struct PrioritiseOptionsSheet: View {
         _topN = State(initialValue: savedN > 0 ? savedN : 20)
     }
 
-    private var aiAvailabilityNote: String {
-        let hasKey = (KeychainService.load() ?? "").isEmpty == false
-        return hasKey
-            ? "Anthropic API available."
-            : "No API key configured. Add one in Settings."
+    private var hasAPIKey: Bool { (KeychainService.load() ?? "").isEmpty == false }
+
+    private var startLabel: String {
+        switch mode {
+        case .aiOnly:   return "Rank — \(selectionLabel)"
+        case .pairwise: return "Compare — \(selectionLabel)"
+        case .both:     return "Rank & Compare — \(selectionLabel)"
+        }
     }
 
     var body: some View {
         NavigationStack {
             Form {
-                Section {
-                    Toggle("Use AI to pre-rank items", isOn: $useAI)
-                    if useAI {
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text("Prioritise criteria")
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
-                            TextField("e.g. work tasks, deadlines this week", text: $criteria)
-                                .textFieldStyle(.plain)
-                        }
-                        .padding(.vertical, 2)
-
-                        Toggle("Limit to top N items", isOn: $topNEnabled)
-                        if topNEnabled {
-                            Stepper("Compare top \(topN) items", value: $topN, in: 2...200)
-                        }
+                Section("Mode") {
+                    Picker("Mode", selection: $mode) {
+                        Text("AI Only").tag(PairwiseSession.Mode.aiOnly)
+                        Text("Pairwise").tag(PairwiseSession.Mode.pairwise)
+                        Text("Both").tag(PairwiseSession.Mode.both)
                     }
-                } header: {
-                    Text("AI seeding")
-                } footer: {
-                    if useAI {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(aiAvailabilityNote)
-                            if topNEnabled {
-                                Text("AI will rank all items but only the top \(topN) will be compared.")
-                            } else {
-                                Text("AI will estimate an initial ranking before you start comparing pairs.")
-                            }
-                        }
-                        .foregroundStyle(.secondary)
-                    } else {
-                        Text("Items start with equal ratings. No AI is used.")
+                    .pickerStyle(.segmented)
+                    .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                }
+
+                if mode != .pairwise {
+                    Section {
+                        TextField("e.g. work tasks, deadlines this week", text: $criteria)
+                    } header: {
+                        Text("Criteria")
+                    } footer: {
+                        Text(hasAPIKey
+                            ? "AI will rank all items against these criteria."
+                            : "No API key. Add one in Settings → AI.")
                             .foregroundStyle(.secondary)
                     }
+                }
+
+                Section {
+                    Toggle("Limit items", isOn: $topNEnabled)
+                    if topNEnabled {
+                        Stepper("Top \(topN) items", value: $topN, in: 1...500)
+                    }
+                } header: {
+                    Text("Items")
+                } footer: {
+                    Group {
+                        if topNEnabled {
+                            switch mode {
+                            case .aiOnly:   Text("AI ranks all items but only the top \(topN) appear in results.")
+                            case .pairwise: Text("Top \(topN) items by prior Elo rating are compared.")
+                            case .both:     Text("AI ranks all items; only the top \(topN) are compared.")
+                            }
+                        } else {
+                            Text("All items are included.")
+                        }
+                    }
+                    .foregroundStyle(.secondary)
                 }
 
                 Section {
                     Button {
                         applyAndStart()
                     } label: {
-                        Text("Start — \(selectionLabel)")
+                        Text(startLabel)
                             .font(.headline)
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, 4)
@@ -668,8 +679,8 @@ private struct PrioritiseOptionsSheet: View {
 
     private func applyAndStart() {
         session.aiCriteria = criteria
-        session.aiTopN = (useAI && topNEnabled) ? topN : nil
-        session.aiPreference = useAI ? .api : .none
+        session.topN = topNEnabled ? topN : nil
+        session.mode = mode
         dismiss()
         onStart()
     }

--- a/Sources/PairwiseReminders/Views/PairwiseView.swift
+++ b/Sources/PairwiseReminders/Views/PairwiseView.swift
@@ -106,7 +106,7 @@ struct PairwiseView: View {
             .tint(.blue)
             .padding(.horizontal)
 
-            if session.seedingFailed && session.aiPreference != .none {
+            if session.seedingFailed && session.mode != .pairwise {
                 Text("AI seeding unavailable — using default ratings")
                     .font(.caption2)
                     .foregroundStyle(.secondary)

--- a/Sources/PairwiseReminders/Views/ResultsView.swift
+++ b/Sources/PairwiseReminders/Views/ResultsView.swift
@@ -1,18 +1,20 @@
 import SwiftUI
+import SwiftData
 
-/// Session summary shown after the Elo comparison finishes ("Done for now" or convergence).
-/// Displays the ranked list and lets the user write results back to Reminders,
-/// then returns to idle so the Prioritise tab resets.
+/// Session summary shown after the session finishes.
+/// Displays the ranked list and lets the user write results back to Reminders.
 struct ResultsView: View {
 
     @EnvironmentObject private var session: PairwiseSession
     @EnvironmentObject private var remindersManager: RemindersManager
     @EnvironmentObject private var eloEngine: EloEngine
+    @Environment(\.modelContext) private var modelContext
 
     @State private var showApplySheet = false
     @State private var showHistory = false
     @State private var applyError: String?
     @State private var applied = false
+    @State private var detailItem: ReminderItem?
     @State private var editingItem: ReminderItem?
 
     var body: some View {
@@ -28,12 +30,15 @@ struct ResultsView: View {
         .navigationBarBackButtonHidden(true)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
-                Button {
-                    showHistory = true
-                } label: {
-                    Image(systemName: "clock.arrow.trianglehead.counterclockwise.rotate.90")
+                HStack(spacing: 12) {
+                    EditButton()
+                    Button {
+                        showHistory = true
+                    } label: {
+                        Image(systemName: "clock.arrow.trianglehead.counterclockwise.rotate.90")
+                    }
+                    .accessibilityLabel("Comparison history")
                 }
-                .accessibilityLabel("Comparison history")
             }
         }
         .sheet(isPresented: $showHistory) {
@@ -48,6 +53,11 @@ struct ResultsView: View {
             }
             .presentationDetents([.medium, .large])
             .presentationDragIndicator(.visible)
+        }
+        .sheet(item: $detailItem) { item in
+            ItemDetailSheet(item: item, onEdit: { editingItem = item })
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
         }
         .sheet(item: $editingItem) { item in
             ReminderEditSheet(item: item)
@@ -64,12 +74,22 @@ struct ResultsView: View {
     // MARK: - Header
 
     private var header: some View {
-        VStack(spacing: 6) {
-            if session.seedingFailed && session.aiPreference != .none {
+        VStack(alignment: .leading, spacing: 6) {
+            if session.seedingFailed && session.mode != .pairwise {
                 Label("AI seeding was unavailable — rankings may be less accurate", systemImage: "info.circle")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .padding(.top, 8)
+                    .padding(.horizontal)
+            }
+            if !session.aiCriteria.isEmpty, session.mode != .pairwise, !session.seedingFailed {
+                let n = session.rankedItems.count
+                let limitText = session.topN != nil ? "top \(n)" : "all \(n)"
+                Text("Ranked by: \(session.aiCriteria) · \(limitText) item\(n == 1 ? "" : "s")")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal)
+                    .padding(.top, session.seedingFailed ? 0 : 8)
             }
             if applied {
                 Label("Applied to Reminders!", systemImage: "checkmark.circle.fill")
@@ -94,7 +114,10 @@ struct ResultsView: View {
             ForEach(Array(session.rankedItems.enumerated()), id: \.element.id) { index, item in
                 SessionRankedRow(item: item, rank: index + 1, total: session.rankedItems.count,
                                  minRating: minR, maxRating: maxR)
-                    .onTapGesture { editingItem = item }
+                    .onTapGesture { detailItem = item }
+            }
+            .onMove { from, to in
+                session.reorderRankedItems(from: from, to: to, context: modelContext)
             }
         }
         .listStyle(.insetGrouped)
@@ -236,13 +259,22 @@ private struct SessionRankedRow: View {
 
             Spacer()
 
-            Text(item.priorityLabel(totalCount: total))
-                .font(.caption.bold())
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
-                .background(priorityColor.opacity(0.15))
-                .foregroundStyle(priorityColor)
-                .clipShape(RoundedRectangle(cornerRadius: 6))
+            VStack(alignment: .trailing, spacing: 4) {
+                Text(item.priorityLabel(totalCount: total))
+                    .font(.caption.bold())
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(priorityColor.opacity(0.15))
+                    .foregroundStyle(priorityColor)
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+
+                if let confidence = item.aiConfidence {
+                    Text("\(confidence)%")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+            }
         }
         .padding(.vertical, 4)
     }
@@ -262,6 +294,80 @@ private struct SessionRankedRow: View {
         case .medium: return .orange
         case .low:    return .yellow
         case .none:   return Color(.secondaryLabel)
+        }
+    }
+}
+
+// MARK: - Item Detail Sheet
+
+private struct ItemDetailSheet: View {
+    let item: ReminderItem
+    let onEdit: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    Text(item.title)
+                        .font(.title3.bold())
+                        .listRowBackground(Color.clear)
+                }
+
+                if item.aiConfidence != nil || item.aiSeedRank != nil || item.aiReasoning != nil {
+                    Section("AI Assessment") {
+                        if let rank = item.aiSeedRank {
+                            LabeledContent("AI Rank", value: "#\(rank)")
+                        }
+                        if let confidence = item.aiConfidence {
+                            LabeledContent("Confidence") {
+                                HStack(spacing: 8) {
+                                    ProgressView(value: Double(confidence), total: 100)
+                                        .tint(confidence > 66 ? .blue : confidence > 33 ? .indigo : .secondary)
+                                        .frame(width: 60)
+                                    Text("\(confidence)%")
+                                        .font(.subheadline)
+                                        .monospacedDigit()
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                        if let reasoning = item.aiReasoning, !reasoning.isEmpty {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Reasoning")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                Text(reasoning)
+                                    .font(.subheadline)
+                            }
+                            .padding(.vertical, 2)
+                        }
+                    }
+                }
+
+                Section("Ranking") {
+                    LabeledContent("Elo Rating", value: String(format: "%.0f", item.eloRating))
+                    LabeledContent("Comparisons", value: "\(item.comparisonCount)")
+                }
+
+                Section {
+                    Button {
+                        dismiss()
+                        onEdit()
+                    } label: {
+                        Label("Edit Reminder…", systemImage: "pencil")
+                    }
+                }
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle("Item Detail")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- **Mode picker** (AI Only / Pairwise / Both) at the top of the Prioritise sheet — replaces the old `useAI` toggle. `AIPreference` enum removed, replaced with `PairwiseSession.Mode`.
- **AI Only mode**: seeding runs → session goes straight to ResultsView (no pairwise). Items ranked by seeded Elo.
- **Pairwise top-N**: limits by prior Elo desc (items with the most ranking history first), falling back to alphabetical for ties.
- **Criteria recap** in ResultsView header: "Ranked by: work tasks · top 20 items"
- **Confidence % badge** next to each row's priority pill
- **Tap row → detail sheet** showing AI rank, confidence bar, one-line reasoning, Elo, and comparisons. "Edit Reminder…" button opens the existing edit sheet.
- **Drag-to-reorder in ResultsView** (behind Edit button in toolbar) — writes new Elo order back to `RankedItemRecord` so it persists across all surfaces.
- `AnthropicService` tool schema now requests `reasoning` per item; stored in `RankedItemRecord.aiReasoning` and loaded back into `ReminderItem` on fetch.
- Follow-up issue #98 filed: multi-select items in Results → refine with pairwise.

## Test plan
- [ ] AI Only, with criteria + top 10: seeding → straight to results, criteria recap visible, confidence pills on rows, tap row shows reasoning
- [ ] Pairwise, no limit: goes to compare without spinner, prior Elo ordering preserved
- [ ] Both, top 20: seeding + pairwise → results (existing behaviour)
- [ ] Drag reorder in ResultsView → Done → reopen list in HomeView → order matches
- [ ] No API key + AI Only: skips seeding gracefully, goes to results with default Elo
- [ ] Apply sheet still writes priorities/dates/flags correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)