### PR TITLE
Fix issue #98: multi-select refinement in ResultsView

### DIFF
--- a/Sources/PairwiseReminders/Models/PairwiseSession.swift
+++ b/Sources/PairwiseReminders/Models/PairwiseSession.swift
@@ -37,6 +37,14 @@ final class PairwiseSession: ObservableObject {
     /// Items sorted by Elo after the session finishes (index 0 = highest priority).
     @Published private(set) var rankedItems: [ReminderItem] = []
 
+    // MARK: - Refinement State
+
+    /// When non-nil, a pairwise refinement is in progress over a subset.
+    /// Holds the full list so `finish()` can splice the refined order back in.
+    private var parentRankedItems: [ReminderItem]?
+    /// Original indices (into `parentRankedItems`) of the items being refined.
+    private var refinementSlots: [Int] = []
+
     // MARK: - Seeding Status
 
     /// True when no AI backend was available or seeding failed — Elo ratings start at default 1000.
@@ -168,9 +176,36 @@ final class PairwiseSession: ObservableObject {
         await continueStart(eloEngine: eloEngine, context: context)
     }
 
+    /// Starts a pairwise refinement over a selected subset of already-ranked items.
+    /// Saves the full ranked list so `finish()` can splice refined positions back in.
+    func startRefinement(items: [ReminderItem], eloEngine: EloEngine) {
+        guard items.count >= 2 else { return }
+        let selectedIDs = Set(items.map(\.id))
+        parentRankedItems = rankedItems
+        refinementSlots = rankedItems.enumerated().compactMap {
+            selectedIDs.contains($0.element.id) ? $0.offset : nil
+        }
+        selectedListIDs = Set(items.compactMap { $0.ekReminder.calendar?.calendarIdentifier })
+        sessionItems = items
+        eloEngine.reset()
+        eloEngine.start(with: items)
+        phase = .comparing
+    }
+
     /// Called by PairwiseView when the user taps "Done for now" or the engine converges.
     func finish(eloEngine: EloEngine, context: ModelContext) {
-        rankedItems = eloEngine.finish(context: context)
+        let refined = eloEngine.finish(context: context)
+        if var parent = parentRankedItems, !refinementSlots.isEmpty {
+            // Splice the refined ordering back into the original positions.
+            for (slotIndex, slot) in refinementSlots.enumerated() where slotIndex < refined.count {
+                parent[slot] = refined[slotIndex]
+            }
+            rankedItems = parent
+            parentRankedItems = nil
+            refinementSlots = []
+        } else {
+            rankedItems = refined
+        }
         phase = .done
     }
 
@@ -200,6 +235,8 @@ final class PairwiseSession: ObservableObject {
         rankedItems = []
         seedingFailed = false
         seedingError = nil
+        parentRankedItems = nil
+        refinementSlots = []
     }
 
     // MARK: - Private

--- a/Sources/PairwiseReminders/Views/ResultsView.swift
+++ b/Sources/PairwiseReminders/Views/ResultsView.swift
@@ -16,6 +16,9 @@ struct ResultsView: View {
     @State private var applied = false
     @State private var detailItem: ReminderItem?
     @State private var editingItem: ReminderItem?
+    @State private var isSelectingForRefinement = false
+    @State private var selectedForRefinement: Set<String> = []
+    @State private var editModeValue: EditMode = .inactive
 
     var body: some View {
         VStack(spacing: 0) {
@@ -23,6 +26,7 @@ struct ResultsView: View {
                 .fixedSize(horizontal: false, vertical: true)
             rankedList
                 .frame(maxHeight: .infinity)
+                .environment(\.editMode, $editModeValue)
             bottomBar
         }
         .navigationTitle("Session Results")
@@ -31,13 +35,35 @@ struct ResultsView: View {
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 HStack(spacing: 12) {
-                    EditButton()
-                    Button {
-                        showHistory = true
-                    } label: {
-                        Image(systemName: "clock.arrow.trianglehead.counterclockwise.rotate.90")
+                    if isSelectingForRefinement {
+                        Button("Cancel") {
+                            isSelectingForRefinement = false
+                            selectedForRefinement = []
+                        }
+                    } else {
+                        Button("Select") {
+                            isSelectingForRefinement = true
+                            selectedForRefinement = []
+                            editModeValue = .inactive
+                        }
+                        Button {
+                            if editModeValue == .active {
+                                editModeValue = .inactive
+                            } else {
+                                editModeValue = .active
+                                isSelectingForRefinement = false
+                                selectedForRefinement = []
+                            }
+                        } label: {
+                            Text(editModeValue == .active ? "Done" : "Edit")
+                        }
+                        Button {
+                            showHistory = true
+                        } label: {
+                            Image(systemName: "clock.arrow.trianglehead.counterclockwise.rotate.90")
+                        }
+                        .accessibilityLabel("Comparison history")
                     }
-                    .accessibilityLabel("Comparison history")
                 }
             }
         }
@@ -112,9 +138,22 @@ struct ResultsView: View {
         let maxR = ratings.max() ?? 1000
         return List {
             ForEach(Array(session.rankedItems.enumerated()), id: \.element.id) { index, item in
+                let isSelected = selectedForRefinement.contains(item.id)
                 SessionRankedRow(item: item, rank: index + 1, total: session.rankedItems.count,
-                                 minRating: minR, maxRating: maxR)
-                    .onTapGesture { detailItem = item }
+                                 minRating: minR, maxRating: maxR,
+                                 isSelecting: isSelectingForRefinement,
+                                 isSelected: isSelected)
+                    .onTapGesture {
+                        if isSelectingForRefinement {
+                            if isSelected {
+                                selectedForRefinement.remove(item.id)
+                            } else {
+                                selectedForRefinement.insert(item.id)
+                            }
+                        } else {
+                            detailItem = item
+                        }
+                    }
             }
             .onMove { from, to in
                 session.reorderRankedItems(from: from, to: to, context: modelContext)
@@ -129,23 +168,52 @@ struct ResultsView: View {
         VStack(spacing: 10) {
             Divider().padding(.bottom, 2)
 
-            Button {
-                showApplySheet = true
-            } label: {
-                Label("Apply to Reminders…", systemImage: "square.and.arrow.down")
+            if isSelectingForRefinement {
+                let count = selectedForRefinement.count
+                Button {
+                    let items = session.rankedItems.filter { selectedForRefinement.contains($0.id) }
+                    isSelectingForRefinement = false
+                    selectedForRefinement = []
+                    session.startRefinement(items: items, eloEngine: eloEngine)
+                } label: {
+                    Label(
+                        count >= 2 ? "Refine \(count) items with Pairwise →" : "Select at least 2 items",
+                        systemImage: "arrow.left.arrow.right"
+                    )
                     .font(.headline)
                     .frame(maxWidth: .infinity)
-            }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.large)
-            .padding(.horizontal)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .disabled(count < 2)
+                .padding(.horizontal)
 
-            Button("Done") {
-                session.reset(eloEngine: eloEngine)
+                Button("Cancel") {
+                    isSelectingForRefinement = false
+                    selectedForRefinement = []
+                }
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .padding(.bottom, 32)
+            } else {
+                Button {
+                    showApplySheet = true
+                } label: {
+                    Label("Apply to Reminders…", systemImage: "square.and.arrow.down")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .padding(.horizontal)
+
+                Button("Done") {
+                    session.reset(eloEngine: eloEngine)
+                }
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .padding(.bottom, 32)
             }
-            .font(.subheadline)
-            .foregroundStyle(.secondary)
-            .padding(.bottom, 32)
         }
     }
 
@@ -225,6 +293,8 @@ private struct SessionRankedRow: View {
     let total: Int
     let minRating: Double
     let maxRating: Double
+    var isSelecting: Bool = false
+    var isSelected: Bool = false
 
     var strength: Double {
         maxRating > minRating ? (item.eloRating - minRating) / (maxRating - minRating) : 0.5
@@ -236,13 +306,20 @@ private struct SessionRankedRow: View {
 
     var body: some View {
         HStack(spacing: 14) {
-            ZStack {
-                Circle()
-                    .fill(badgeColor)
-                    .frame(width: 38, height: 38)
-                Text("\(rank)")
-                    .font(.system(.body, design: .rounded).bold())
-                    .foregroundStyle(.white)
+            if isSelecting {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.title3)
+                    .foregroundStyle(isSelected ? .blue : Color(.tertiaryLabel))
+                    .frame(width: 28)
+            } else {
+                ZStack {
+                    Circle()
+                        .fill(badgeColor)
+                        .frame(width: 38, height: 38)
+                    Text("\(rank)")
+                        .font(.system(.body, design: .rounded).bold())
+                        .foregroundStyle(.white)
+                }
             }
 
             VStack(alignment: .leading, spacing: 4) {
@@ -252,31 +329,36 @@ private struct SessionRankedRow: View {
                 Text(item.listName)
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                ProgressView(value: strength)
-                    .tint(strengthColor)
-                    .frame(width: 80)
+                if !isSelecting {
+                    ProgressView(value: strength)
+                        .tint(strengthColor)
+                        .frame(width: 80)
+                }
             }
 
             Spacer()
 
-            VStack(alignment: .trailing, spacing: 4) {
-                Text(item.priorityLabel(totalCount: total))
-                    .font(.caption.bold())
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(priorityColor.opacity(0.15))
-                    .foregroundStyle(priorityColor)
-                    .clipShape(RoundedRectangle(cornerRadius: 6))
+            if !isSelecting {
+                VStack(alignment: .trailing, spacing: 4) {
+                    Text(item.priorityLabel(totalCount: total))
+                        .font(.caption.bold())
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(priorityColor.opacity(0.15))
+                        .foregroundStyle(priorityColor)
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
 
-                if let confidence = item.aiConfidence {
-                    Text("\(confidence)%")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                        .monospacedDigit()
+                    if let confidence = item.aiConfidence {
+                        Text("\(confidence)%")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                    }
                 }
             }
         }
         .padding(.vertical, 4)
+        .contentShape(Rectangle())
     }
 
     private var badgeColor: Color {


### PR DESCRIPTION
## Summary
- Adds **Select** toolbar button in ResultsView that enters a multi-select mode
- Selected rows show a circle/checkmark indicator; Elo strength bar and priority label are hidden while selecting to reduce visual noise
- Bottom bar shows **"Refine N items with Pairwise →"** button (enabled when ≥ 2 selected); tapping launches `session.startRefinement()` directly into `.comparing`
- `PairwiseSession.startRefinement(items:eloEngine:)` saves `parentRankedItems` + `refinementSlots` and starts Elo engine on the subset without any seeding
- `finish()` splices the refined ordering back into the original positions in the full ranked list
- Select mode and drag-reorder (Edit mode) are mutually exclusive — switching to one cancels the other

## Test plan
- [ ] Start session → finish → Results screen
- [ ] Tap **Select**: rows show circles, bottom bar shows "Select at least 2 items"
- [ ] Tap 2+ rows: checkmarks appear, bottom bar enables "Refine N items with Pairwise →"
- [ ] Tap **Refine**: pairwise comparison starts on only the selected items
- [ ] Complete or bail from pairwise: Results screen returns showing the full list with refined items in their updated positions
- [ ] Refined items appear in new rank order relative to their original slots
- [ ] **Cancel** in toolbar or bottom bar exits Select mode without starting a session
- [ ] Tapping **Edit** while in Select mode cancels selection (and vice versa)
- [ ] Drag reorder still persists Elo correctly when not in Select mode

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)