### PR TITLE
Pairwise: swipe direction hints + glassy About-equal button

### DIFF
--- a/Sources/PairwiseReminders/Views/PairwiseView.swift
+++ b/Sources/PairwiseReminders/Views/PairwiseView.swift
@@ -169,14 +169,30 @@ struct PairwiseView: View {
                 .padding(.horizontal)
                 .simultaneousGesture(LongPressGesture().onEnded { _ in editingItem = bottomItem })
 
-            // Secondary action
+            // Swipe direction hints — always visible so the gesture is discoverable
+            HStack {
+                Label("Top card", systemImage: "arrow.left")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                Spacer()
+                Label("This one", systemImage: "arrow.right")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(.horizontal, 28)
+            .padding(.top, 8)
+
+            // Secondary action — glassy pill button
             Button { engine.equal() } label: {
                 Text("About equal")
+                    .font(.subheadline.weight(.medium))
+                    .padding(.horizontal, 28)
+                    .padding(.vertical, 11)
+                    .background(.regularMaterial, in: Capsule())
+                    .overlay(Capsule().strokeBorder(Color.primary.opacity(0.08), lineWidth: 0.5))
             }
-            .buttonStyle(.bordered)
-            .controlSize(.regular)
-            .tint(.secondary)
-            .padding(.top, 12)
+            .buttonStyle(.plain)
+            .padding(.top, 8)
 
             Spacer(minLength: 20)
         }


### PR DESCRIPTION
## Summary
- Added a **"← Top card / This one →"** hint row below the swipe card so the gesture directions are passively visible before the user touches the card (previously hints only appeared mid-drag via the swipe overlay)
- Replaced the `.bordered` "About equal" button with a **glassy Capsule** — `.regularMaterial` background + thin `Capsule` stroke overlay — matching the frosted-glass idiom used in Apple's own apps

## Test plan
- [ ] Pairwise comparison screen shows "← Top card" / "This one →" labels at the bottom edges between the card and the About equal button
- [ ] Dragging left/right triggers the existing colour overlay as before
- [ ] "About equal" button has frosted glass appearance (translucent, slightly blurred background)
- [ ] Tapping About equal still records a draw correctly

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)