### PR TITLE
Results: orange seeding error, stable row heights

### DIFF
--- a/Sources/PairwiseReminders/Views/ResultsView.swift
+++ b/Sources/PairwiseReminders/Views/ResultsView.swift
@@ -74,14 +74,26 @@ struct ResultsView: View {
     // MARK: - Header
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: 0) {
+            // Seeding failure banner — orange with specific error when available.
             if session.seedingFailed && session.mode != .pairwise {
-                Label("AI seeding was unavailable — rankings may be less accurate", systemImage: "info.circle")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .padding(.top, 8)
-                    .padding(.horizontal)
+                if let errorMessage = session.seedingError {
+                    Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .padding(.horizontal)
+                        .padding(.top, 8)
+                        .padding(.bottom, 4)
+                } else {
+                    Label("AI seeding was unavailable — rankings may be less accurate", systemImage: "info.circle")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal)
+                        .padding(.top, 8)
+                        .padding(.bottom, 4)
+                }
             }
+            // Criteria recap — only when seeding succeeded.
             if !session.aiCriteria.isEmpty, session.mode != .pairwise, !session.seedingFailed {
                 let n = session.rankedItems.count
                 let limitText = session.topN != nil ? "top \(n)" : "all \(n)"
@@ -89,7 +101,8 @@ struct ResultsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .padding(.horizontal)
-                    .padding(.top, session.seedingFailed ? 0 : 8)
+                    .padding(.top, 8)
+                    .padding(.bottom, 4)
             }
             if applied {
                 Label("Applied to Reminders!", systemImage: "checkmark.circle.fill")
@@ -268,12 +281,12 @@ private struct SessionRankedRow: View {
                     .foregroundStyle(priorityColor)
                     .clipShape(RoundedRectangle(cornerRadius: 6))
 
-                if let confidence = item.aiConfidence {
-                    Text("\(confidence)%")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                        .monospacedDigit()
-                }
+                // Fixed-height slot keeps row heights uniform whether or not confidence is present.
+                Text(item.aiConfidence.map { "\($0)%" } ?? "")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+                    .frame(height: 14)
             }
         }
         .padding(.vertical, 4)


### PR DESCRIPTION
## Summary
- Seeding failure now shows **orange** when a specific error message is available (e.g. "API: timeout", "API: unauthorized"), not just a muted grey info banner. Generic failure without a message keeps the grey banner.
- Normalized header padding — removed the `session.seedingFailed ? 0 : 8` conditional that caused layout shifts depending on which banner was shown.
- `SessionRankedRow` now uses a **fixed-height slot** for the confidence badge, so rows with and without AI data are the same height and the list doesn't reflow.

## Test plan
- [ ] AI Only session with bad API key → Results header shows orange error text (not grey)
- [ ] AI Only session where seeding fails silently (no error string) → grey info banner as before
- [ ] Pairwise-only session → no banner at all
- [ ] Row heights in the ranked list are consistent whether items have `aiConfidence` or not
- [ ] "Applied to Reminders!" banner slides in smoothly without shifting the list

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)