### PR TITLE
Startup: splash screen covers EventKit/SwiftData sync on cold launch

### DIFF
--- a/Sources/PairwiseReminders/Views/ContentView.swift
+++ b/Sources/PairwiseReminders/Views/ContentView.swift
@@ -1,14 +1,26 @@
 import SwiftUI
 
-/// Root view. Requests Reminders access, syncs with EventKit, then shows HomeView.
+/// Root view. Shows a splash screen while bootstrapping, then fades into HomeView.
 struct ContentView: View {
 
     @EnvironmentObject private var remindersManager: RemindersManager
     @Environment(\.modelContext) private var modelContext
 
+    @State private var isReady = false
+
     var body: some View {
-        HomeView()
-            .task { await bootstrap() }
+        ZStack {
+            // HomeView starts loading behind the splash so it's ready the moment we fade in.
+            HomeView()
+                .opacity(isReady ? 1 : 0)
+
+            if !isReady {
+                SplashView()
+                    .transition(.opacity)
+            }
+        }
+        .animation(.easeOut(duration: 0.4), value: isReady)
+        .task { await bootstrap() }
     }
 
     private func bootstrap() async {
@@ -18,5 +30,42 @@ struct ContentView: View {
         // syncWithEventKit calls fetchLists() internally and updates SwiftData.
         // Lists may already be populated from init() if access was pre-granted.
         await remindersManager.syncWithEventKit(context: modelContext)
+        isReady = true
+    }
+}
+
+// MARK: - Splash Screen
+
+private struct SplashView: View {
+    var body: some View {
+        VStack(spacing: 20) {
+            Spacer()
+
+            ZStack {
+                Circle()
+                    .fill(.blue.opacity(0.1))
+                    .frame(width: 120, height: 120)
+                Image(systemName: "arrow.left.arrow.right.circle.fill")
+                    .font(.system(size: 60))
+                    .foregroundStyle(.blue)
+                    .symbolEffect(.pulse)
+            }
+
+            VStack(spacing: 6) {
+                Text("Retinder")
+                    .font(.largeTitle.bold())
+                Text("Syncing your reminders…")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            ProgressView()
+                .scaleEffect(1.2)
+                .padding(.bottom, 60)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.systemBackground))
     }
 }


### PR DESCRIPTION
## Summary
- `ContentView` now shows a `SplashView` (app icon + name + spinner) while `bootstrap()` runs: EventKit permission request + `syncWithEventKit` (EventKit fetch + SwiftData inserts/deletes)
- `HomeView` starts loading behind the splash so it's immediately interactive the moment the 0.4s fade-in begins — no perceptible delay after the splash
- `isReady` flips after bootstrap completes, triggering `.easeOut` opacity animation from splash to home
- Handles all launch states: first launch (permission prompt fires during splash), subsequent launches (quick path if access already granted)

## Test plan
- [ ] Fresh install: splash appears, permission prompt shows on top of it, after granting access splash fades into HomeView with lists loaded
- [ ] Subsequent launches: splash appears briefly, fades into loaded HomeView (should be < 1s on warm data)
- [ ] Large dataset (100+ reminders): splash covers the SwiftData sync, HomeView ready when fade starts
- [ ] Splash shows app icon, "Retinder" title, "Syncing your reminders…" subtitle, spinner
- [ ] No visible blank/frozen frame before splash appears

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)