### PR TITLE
UI polish C: settings, FAB, pairwise background, Apply+Done side-by-side

### DIFF
--- a/Sources/PairwiseReminders/Views/HomeView.swift
+++ b/Sources/PairwiseReminders/Views/HomeView.swift
@@ -163,14 +163,11 @@ struct HomeView: View {
             .safeAreaInset(edge: .bottom) { prioritiseButton }
             .navigationTitle("Retinder")
             .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
-            .toolbarBackground(.visible, for: .navigationBar)
             .navigationDestination(item: $selectedList) { calendar in
                 ListDetailView(calendar: calendar)
             }
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
-                    // Cancel is shown whenever there's an active selection — even outside
-                    // Select mode — so the user can always clear a stale selection.
                     if isSelecting || !itemSelection.isEmpty {
                         Button("Cancel") {
                             editMode = .inactive
@@ -190,54 +187,53 @@ struct HomeView: View {
                         .font(.subheadline)
                     }
                 }
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    HStack(spacing: 12) {
-                        // History stays visible in all modes.
-                        Button { showHistory = true } label: {
-                            Image(systemName: "clock.arrow.trianglehead.counterclockwise.rotate.90")
-                        }
-                        .accessibilityLabel("Comparison history")
 
-                        if !isSelecting {
-                            // Group By and Sort By as independent menus (Files-app style).
-                            Menu {
+                // Settings gear — always visible so users can find it.
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button { showSettings = true } label: {
+                        Image(systemName: "gear")
+                    }
+                    .accessibilityLabel("Settings")
+                }
+
+                // Group / Sort / History collapsed into one menu.
+                if !isSelecting {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Menu {
+                            Section("Group By") {
                                 Picker("Group By", selection: $groupingMode) {
                                     ForEach(GroupingMode.allCases, id: \.self) { mode in
                                         Text(mode.label).tag(mode)
                                     }
                                 }
-                            } label: {
-                                Image(systemName: "square.grid.2x2")
                             }
-                            .accessibilityLabel("Group by")
-
-                            Menu {
+                            Section("Sort By") {
                                 Picker("Sort By", selection: $sortMode) {
                                     ForEach(SortMode.allCases, id: \.self) { mode in
                                         Text(mode.label).tag(mode)
                                     }
                                 }
-                            } label: {
-                                Image(systemName: "arrow.up.arrow.down.circle")
                             }
-                            .accessibilityLabel("Sort by")
-
-                            Button { showSettings = true } label: {
-                                Image(systemName: "gear")
+                            Divider()
+                            Button("Comparison History", systemImage: "clock.arrow.trianglehead.counterclockwise.rotate.90") {
+                                showHistory = true
                             }
-                            .accessibilityLabel("Settings")
+                        } label: {
+                            Image(systemName: "ellipsis.circle")
                         }
-
-                        Button(isSelecting ? "Done" : "Select") {
-                            if editMode == .active {
-                                editMode = .inactive
-                                itemSelection = []
-                            } else {
-                                editMode = .active
-                            }
-                        }
-                        .font(.subheadline.weight(isSelecting ? .semibold : .regular))
                     }
+                }
+
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(isSelecting ? "Done" : "Select") {
+                        if editMode == .active {
+                            editMode = .inactive
+                            itemSelection = []
+                        } else {
+                            editMode = .active
+                        }
+                    }
+                    .font(.subheadline.weight(isSelecting ? .semibold : .regular))
                 }
             }
             .fullScreenCover(isPresented: $showPrioritise) {
@@ -285,7 +281,7 @@ struct HomeView: View {
                         }
                     }
                 }
-                .presentationDetents([.medium, .large])
+                .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
             }
             // Bridge: when ListDetailView sets pendingListIDs, pre-select + open options.
@@ -518,14 +514,31 @@ struct HomeView: View {
     private var hasSelection: Bool { !itemSelection.isEmpty }
 
     private var prioritiseButton: some View {
-        FloatingGlassButton(title: prioritiseLabel, prominent: hasSelection) {
-            if hasSelection {
-                showPrioritiseOptions = true
-            } else {
-                editMode = .active
+        HStack {
+            Spacer()
+            Button {
+                if hasSelection {
+                    showPrioritiseOptions = true
+                } else {
+                    editMode = .active
+                }
+            } label: {
+                Label(prioritiseLabel, systemImage: "arrow.left.arrow.right")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(hasSelection ? .white : .primary)
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 13)
+                    .background(
+                        Capsule()
+                            .fill(.ultraThinMaterial)
+                            .overlay(Capsule().fill(hasSelection ? Color.blue.opacity(0.9) : .clear))
+                            .overlay(Capsule().strokeBorder(Color.primary.opacity(0.08), lineWidth: 0.5))
+                            .shadow(color: .black.opacity(0.2), radius: 12, y: 5)
+                    )
             }
+            .buttonStyle(.plain)
         }
-        .padding(.horizontal, 20)
+        .padding(.trailing, 20)
         .padding(.bottom, 12)
     }
 

--- a/Sources/PairwiseReminders/Views/PairwiseView.swift
+++ b/Sources/PairwiseReminders/Views/PairwiseView.swift
@@ -57,6 +57,7 @@ struct PairwiseView: View {
                 Spacer()
             }
         }
+        .background(Color(.systemGroupedBackground).ignoresSafeArea())
         .animation(.spring(response: 0.35, dampingFraction: 0.8), value: engine.comparisonCount)
         .onChange(of: engine.comparisonCount) { _, _ in
             withAnimation(.spring(response: 0.3)) { dragOffset = .zero }
@@ -342,12 +343,8 @@ private struct PairwiseCardBody: View {
         .frame(maxWidth: .infinity, minHeight: 170)
         .background(
             RoundedRectangle(cornerRadius: 22, style: .continuous)
-                .fill(.ultraThinMaterial)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 22, style: .continuous)
-                        .strokeBorder(Color.primary.opacity(0.06), lineWidth: 1)
-                )
-                .shadow(color: .black.opacity(0.14), radius: 14, y: 6)
+                .fill(.regularMaterial)
+                .shadow(color: .black.opacity(0.1), radius: 16, y: 4)
         )
     }
 }

--- a/Sources/PairwiseReminders/Views/ResultsView.swift
+++ b/Sources/PairwiseReminders/Views/ResultsView.swift
@@ -213,25 +213,31 @@ struct ResultsView: View {
                 .background(Capsule().fill(.ultraThinMaterial))
                 .overlay(Capsule().strokeBorder(Color.primary.opacity(0.08), lineWidth: 0.5))
             } else {
-                FloatingGlassButton(
-                    title: "Apply to Reminders",
-                    systemImage: "square.and.arrow.down",
-                    prominent: true
-                ) { showApplySheet = true }
+                HStack(spacing: 12) {
+                    FloatingGlassButton(
+                        title: "Done",
+                        systemImage: "checkmark",
+                        prominent: false
+                    ) { session.reset(eloEngine: eloEngine) }
 
-                Button("Done") {
-                    session.reset(eloEngine: eloEngine)
+                    FloatingGlassButton(
+                        title: "Apply",
+                        systemImage: "square.and.arrow.down",
+                        prominent: true
+                    ) { showApplySheet = true }
                 }
-                .font(.subheadline.weight(.medium))
-                .foregroundStyle(.secondary)
-                .padding(.vertical, 10)
-                .padding(.horizontal, 22)
-                .background(Capsule().fill(.ultraThinMaterial))
-                .overlay(Capsule().strokeBorder(Color.primary.opacity(0.08), lineWidth: 0.5))
             }
         }
         .padding(.horizontal, 20)
-        .padding(.bottom, 8)
+        .padding(.vertical, 12)
+        .background(
+            LinearGradient(
+                colors: [Color(.systemBackground).opacity(0), Color(.systemBackground)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea()
+        )
     }
 
     // MARK: - Tap Handling
@@ -672,6 +678,8 @@ struct ApplySheet: View {
             }
             .navigationTitle("Apply to Reminders")
             .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackground(.regularMaterial, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }


### PR DESCRIPTION
Fixes #117.

## Summary

- **Settings always findable**: gear icon is its own `ToolbarItem`; Group / Sort / History collapsed into an `ellipsis.circle` menu so the nav bar doesn't overflow into a "..." button
- **Frosted bar + large-title text-push**: removed `.toolbarBackground(.visible)` so the nav bar is transparent at the top of the list and appears (frosted) only when content scrolls under it — matches the iOS Reminders / Calendar behavior
- **Prioritise FAB**: full-width centred pill → compact trailing-aligned capsule with `arrow.left.arrow.right` icon
- **Prioritise options sheet**: detent `[.medium, .large]` → `[.large]` — sheet opens at full height so the Start button isn't clipped
- **Apply + Done side by side**: replaced VStack stack with an HStack; both are `FloatingGlassButton` with icons (`checkmark` / `square.and.arrow.down`)
- **Bottom bar gradient**: content-to-systemBackground fade gradient so the ranked list doesn't bleed through the buttons awkwardly
- **Apply sheet nav bar**: `.regularMaterial` toolbar so the sheet header looks solid, not floating
- **Pairwise card background**: screen now uses `Color(.systemGroupedBackground)` so `regularMaterial` cards visually contrast against the backdrop — `ultraThinMaterial` over white was essentially invisible

## Surfaces touched

- [x] Home — `Docs/Verification/Home.md`
- [x] Prioritise start — `Docs/Verification/PrioritiseStart.md`
- [x] Pairwise — `Docs/Verification/Pairwise.md`
- [x] Results — `Docs/Verification/Results.md`

## Test plan

- [ ] Home: gear icon visible in toolbar regardless of mode
- [ ] Home: large title "Retinder" at top of scroll; collapses + frosted bar appears on scroll
- [ ] Home: Prioritise FAB is a trailing compact pill with icon; no longer full-width
- [ ] Prioritise options: sheet opens at full height
- [ ] Results: Apply + Done buttons appear side by side at equal width
- [ ] Results: gradient background visible between list and buttons
- [ ] Apply sheet: nav bar looks solid/regular, not awkward glass
- [ ] Pairwise: cards have visible depth/contrast against the grey-tinted screen background

[verification: n/a — docs will be updated in follow-up verification pass once UI is signed off]

🤖 Generated with [Claude Code](https://claude.com/claude-code)