### PR TITLE
UI polish D: universal sparklines, dual-swipe, nav integration, tap simplification

### DIFF
--- a/Docs/Verification/Home.md
+++ b/Docs/Verification/Home.md
@@ -1,18 +1,19 @@
 # Verification — Home
 
-**Last verified:** 2026-04-19 against `7a291db`
+**Last verified:** 2026-04-19 against `855b45e`
 **Source:** `Sources/PairwiseReminders/Views/HomeView.swift`
 **Related issues:** #101, #106, #114
 
 ## Scope
-The main landing screen: segmented mode picker (Lists / All Reminders / Due Date), selection mode, prioritise entry, Elo sparklines on list headers, and row interactions (tap = edit, long-press = toggle select, or the reverse depending on `home_tap_default`).
+The main landing screen: segmented mode picker (Lists / All Reminders / Due Date), selection mode, prioritise entry, universal SparklinePill sparklines on list headers and item rows, and row interactions (tap = edit out of select mode, long-press = toggle select).
 
 ## Golden path
 - [ ] Toggle between Lists / All Reminders / Due Date — content updates, no flicker.
-- [ ] Lists mode: each list header shows a sparkline for items with `comparisonCount > 0`; bars grow left-to-right (lowest-Elo left, highest right).
-- [ ] Sparkline bar heights are scaled against the *global* min/max across all lists, so different lists are visually comparable.
-- [ ] Expand a list — reminder rows appear; tap a row with tap-default `.edit` opens `ReminderEditSheet`.
-- [ ] Long-press a row (tap-default `.edit`) — toggles selection on that row.
+- [ ] Lists mode: each list header shows a combined sparkline (HStack of `SparklinePill`s) for items with `comparisonCount > 0`; pills are fixed max-height with proportional fill, ordered low → high.
+- [ ] Sparkline fills are scaled against the *global* min/max across all lists, so different lists are visually comparable.
+- [ ] Expand a list — reminder rows appear; each ranked row shows a single `SparklinePill` on the right reflecting its relative Elo strength.
+- [ ] Tap a row (out of select mode) — opens `ReminderEditSheet`.
+- [ ] Long-press a row — toggles selection on that row.
 - [ ] Tap the Prioritise pill at the bottom with a selection — Prioritise flow opens prefilled.
 - [ ] Tap the Prioritise pill with nothing selected — silently enters Select mode (no alert).
 - [ ] In Select mode, tap a list header row — all items in that list become selected (cascade).
@@ -21,16 +22,16 @@ The main landing screen: segmented mode picker (Lists / All Reminders / Due Date
 - [ ] Gear icon opens `SettingsView` as a sheet.
 - [ ] Bottom Prioritise pill is a floating glass capsule that stays above content on scroll.
 - [ ] Top navigation bar uses `ultraThinMaterial` (frosted) and the title ("Retinder") transitions correctly on scroll.
+- [ ] Filter/group icon (line.3.horizontal.decrease.circle) opens the Group By / Sort By menu.
 
 ## Edge cases
-- [ ] Set `home_tap_default = .select` in Settings — tap now toggles selection, long-press opens edit sheet. Verify the swap is immediate (no relaunch needed).
 - [ ] No lists at all (fresh install, no permission) — empty state renders; Prioritise pill is disabled/hidden.
-- [ ] A list with zero ranked items — sparkline is absent (not a flat bar).
+- [ ] A list with zero ranked items — sparkline is absent (not a flat track).
 - [ ] All Reminders mode with 100+ items — scroll is smooth.
-- [ ] Due Date mode — items group correctly under Overdue / Today / Tomorrow / This Week / Later / No date.
+- [ ] Due Date mode — items group correctly under Today / Tomorrow / This Week / Later / No date.
 - [ ] Long reminder title (multiline) — row height grows; layout doesn't clip.
 - [ ] Section gap between list groups is tight (`.listSectionSpacing(.compact)`), not the default chunky iOS grouped inset.
+- [ ] Unranked items (comparisonCount == 0) show no sparkline pill.
 
 ## Known gaps
 - Widget surface not yet built (tracked separately).
-- No pull-to-refresh on the Home list — EventKit sync only runs at bootstrap.

--- a/Docs/Verification/Pairwise.md
+++ b/Docs/Verification/Pairwise.md
@@ -1,36 +1,39 @@
 # Verification — Pairwise comparison
 
-**Last verified:** 2026-04-19 against `7a291db`
+**Last verified:** 2026-04-19 against `855b45e`
 **Source:** `Sources/PairwiseReminders/Views/PairwiseView.swift`
 **Related issues:** #102, #115
 
 ## Scope
-The Tinder-style comparison screen: frosted header ("Which matters more?" + progress + N left), two identical `PairwiseCardBody` cards, drag-to-pick gestures, Undo and Done-for-now glass pills in the toolbar, "About equal" action.
+The Tinder-style comparison screen: nav bar "Which matters more?" title + progress band below it, two identical `PairwiseCardBody` cards (both swipeable), "About equal" button between the cards, Undo and Done-for-now glass pills in the toolbar, gear icon for Settings.
 
 ## Golden path
 - [ ] Cards render at **equal width and equal min-height** regardless of content length.
-- [ ] Both cards have `.ultraThinMaterial` backing with the subtle stroke and soft shadow (Live-Activity look).
-- [ ] Tap the top card with tap-default `.choose` — picks it, next pair enters from the right.
-- [ ] Tap the bottom card — picks it, next pair enters.
-- [ ] Drag bottom card right past threshold — card slides off-screen right with fade + scale, next pair enters.
-- [ ] Drag bottom card left past threshold — card slides off-screen left.
-- [ ] Sub-threshold drag — card rubber-bands back to centre.
+- [ ] Both cards use `Color(.secondarySystemBackground)` backing with soft shadow — good contrast in light and dark mode.
+- [ ] Progress band appears immediately below the nav bar, visually connected via matching `ultraThinMaterial`.
+- [ ] "Which matters more?" appears as the navigation bar title.
+- [ ] "N left" label and progress bar fill as comparisons accrue; "Almost done" appears when `estimatedRemaining == 0`.
+- [ ] Tap either card — picks that card; next pair enters from the right.
+- [ ] Drag top card right past threshold — top card wins; flies off screen right.
+- [ ] Drag top card left past threshold — bottom card wins; top card flies off left.
+- [ ] Drag bottom card right past threshold — bottom card wins; flies off right.
+- [ ] Drag bottom card left past threshold — top card wins; bottom card flies off left.
+- [ ] Sub-threshold drag on either card — card rubber-bands back to centre.
+- [ ] Swipe overlay: green + thumbs-up when dragging right ("This one"), blue + arrow-up when dragging left ("Top one").
+- [ ] "About equal" button sits between the two cards; tapping gives a 0.5/0.5 Elo update.
 - [ ] Undo pill (leading) disables/dims before any choice, enables after first choice.
-- [ ] Tapping Undo reverts the last decision; the pair that was shown before reappears.
-- [ ] Done for now pill (trailing) ends the session and transitions to `.done` (Results).
-- [ ] Header progress bar fills as comparisons accrue; "N left" updates monotonically.
-- [ ] "Almost done" appears when `estimatedRemaining == 0` and the engine is finishing up.
-- [ ] "About equal" pill splits a 0.5/0.5 Elo update between the pair.
+- [ ] Tapping Undo reverts the last decision.
+- [ ] Done for now pill (trailing) ends the session and transitions to Results.
+- [ ] Gear icon (trailing) opens Settings sheet.
+- [ ] Long-press either card — opens `ReminderEditSheet`.
 
 ## Edge cases
-- [ ] Change `pairwise_tap_default = .edit` in Settings — tap now opens `ReminderEditSheet`, long-press picks. Swipe still picks regardless of setting.
-- [ ] Long-press with tap-default `.choose` — opens `ReminderEditSheet`.
-- [ ] Edit a reminder via the sheet — on dismiss, the card reflects the edit immediately (title, notes).
-- [ ] Seeding-failed banner appears below the header when `session.seedingFailed && mode != .pairwise`.
-- [ ] Reach convergence (keep comparing a short list until `isConverged`) — "Ranking settled!" state appears; tapping "See Results" transitions to `.done`.
-- [ ] Rapid-fire swipes (3+ in a second) — no stuck mid-transition state; exit animation completes each time before next pair appears.
-- [ ] Drag during the swipe-off animation is ignored (no interference with the chosen-card's exit).
+- [ ] Edit a reminder via the sheet — on dismiss, the card reflects the edit immediately.
+- [ ] Seeding-failed note appears in progress band when `session.seedingFailed && mode != .pairwise`.
+- [ ] Reach convergence — "Ranking settled!" state appears; tapping "See Results" transitions to `.done`.
+- [ ] Rapid-fire swipes — no stuck mid-transition state.
 - [ ] Session with exactly 2 items — one comparison, then converges.
+- [ ] Top and bottom card drag states are independent — dragging one card doesn't affect the other's position.
 
 ## Known gaps
 - No haptic feedback on choice (tracked separately).

--- a/Docs/Verification/Results.md
+++ b/Docs/Verification/Results.md
@@ -1,35 +1,35 @@
 # Verification — Results
 
-**Last verified:** 2026-04-19 against `7a291db`
+**Last verified:** 2026-04-19 against `855b45e`
 **Source:** `Sources/PairwiseReminders/Views/ResultsView.swift`
 **Related issues:** #103, #114
 
 ## Scope
-Ranked-list view shown after `PairwiseView` finishes or AI Only mode completes: Elo-sorted rows, drag-to-reorder, per-row edit sheet, refinement flow (re-rank a subset), Apply sheet (tiered priorities + optional due dates), Back to Compare, and Cancel/Done floating glass buttons.
+Ranked-list view shown after `PairwiseView` finishes or AI Only mode completes: Elo-sorted rows with `SparklinePill` strength indicators, drag-to-reorder, per-row detail/edit, refinement flow, Apply sheet (tiered priorities + optional due dates), Back to Compare, and Done/Apply floating glass buttons.
 
 ## Golden path
 - [ ] Items render in descending Elo order (highest priority at the top).
+- [ ] Each row shows a `SparklinePill` on the right reflecting its relative Elo strength (no rank number badges).
+- [ ] AI confidence percentage appears alongside the list name when present (e.g. "Work · 87%").
 - [ ] Orange banner appears at the top if `session.seedingFailed && session.mode != .pairwise`.
 - [ ] Drag a row to reorder — Elo rating is recalculated in-place; reorder persists via SwiftData.
-- [ ] Tap a row with tap-default `.edit` — `ReminderEditSheet` opens.
-- [ ] Save an edit — dismissing the sheet reflects changes on the row immediately.
-- [ ] Select multiple rows → Refine — session restarts in `.comparing` with only those items, splicing back into ranked positions on finish.
-- [ ] Tap Apply floating glass button — Apply sheet opens.
+- [ ] Tap a row — `ItemDetailSheet` opens (always, regardless of any settings).
+- [ ] Long-press a row — enters selection mode and toggles that row.
+- [ ] Select multiple rows → Refine — session restarts in `.comparing` with only those items.
+- [ ] Tap Apply floating glass button — Apply sheet opens with title "Apply".
 - [ ] Apply sheet: assign High / Medium / Low tiers; toggle due-date defaults per tier.
 - [ ] Confirm apply — EventKit priority + due date are saved on each item (batch `commit`).
-- [ ] Back to Compare button (top-leading) — continues the comparison session on the current ranked list.
+- [ ] Back to Compare button (top-leading) — continues the comparison session.
 - [ ] Done floating button — resets session to `.idle`, fullScreenCover dismisses.
-- [ ] Cancel floating button — same as Done (session reset, cover dismissed) — no EventKit side-effects.
 
 ## Edge cases
 - [ ] Row heights stay stable during scroll (no jitter from async cell sizing).
-- [ ] Refine with 1 item selected — action disabled / no-op (needs at least 2).
-- [ ] Apply sheet respects tier defaults from Settings (`defaultHighDueTarget`, etc.).
-- [ ] Apply with a custom due date per tier — saves that exact date, not the default.
-- [ ] Back to Compare with a 1-item ranked list — action disabled / no-op.
-- [ ] Done after a refine flow — ranked list reflects spliced order, not the refined subset alone.
+- [ ] Refine with 1 item selected — action disabled (needs at least 2).
+- [ ] Apply sheet respects tier defaults from Settings.
+- [ ] Apply with a custom due date per tier — saves that exact date.
 - [ ] Top navigation bar uses `ultraThinMaterial`; floating glass buttons sit on a safe-area inset at the bottom.
+- [ ] Session stopped early — ranked items still show sparkline pills and confidence; Apply is available.
 
 ## Known gaps
-- No per-tier item-count preview on the Apply sheet.
 - No "undo apply" — if you apply wrong priorities, you must rerun.
+- No per-tier item-count preview on the Apply sheet.

--- a/Docs/Verification/Settings.md
+++ b/Docs/Verification/Settings.md
@@ -1,28 +1,24 @@
 # Verification — Settings
 
-**Last verified:** 2026-04-19 against `7a291db`
+**Last verified:** 2026-04-19 against `855b45e`
 **Source:** `Sources/PairwiseReminders/Views/SettingsView.swift`
 **Related issues:** #114
 
 ## Scope
-Sheet launched from the Home gear icon: Anthropic API key entry + masking + connection test, interaction defaults (Home tap-default, Pairwise tap-default), and due-date defaults per priority tier.
+Sheet launched from the Home gear icon (and the Pairwise gear icon): Anthropic API key entry + masking + connection test, and due-date defaults per priority tier. Interaction tap-default settings have been removed — tapping always edits out of select mode, long-press always selects.
 
 ## Golden path
 - [ ] Enter an API key — Save is disabled until the field is non-empty; tapping Save persists to Keychain; "Saved" green label appears briefly.
 - [ ] Toggle the eye icon — masks/unmasks the stored value.
 - [ ] Tap Test connection — spinner appears, then either green "Connected" or red error with code/message.
-- [ ] Home tap default picker — switching between `.edit` / `.select` immediately changes Home row tap behaviour without restart.
-- [ ] Pairwise tap default picker — switching between `.choose` / `.edit` immediately changes Pairwise card tap behaviour.
 - [ ] Due-date defaults (High / Medium / Low) — each picker persists via UserDefaults and propagates to the Apply sheet in Results.
-- [ ] Closing the sheet returns to Home without mutating session state.
+- [ ] Closing the sheet returns without mutating session state.
 
 ## Edge cases
 - [ ] Empty API key + Test connection — button is disabled (no hit to the API).
 - [ ] Bad API key (`sk-ant-invalid`) — Test connection surfaces an "Error 401" or similar with a readable message.
 - [ ] Offline — Test connection surfaces a network error message, not a spinner that hangs.
 - [ ] "Custom" due-date target is not offered in the pickers (filtered out) — only absolute buckets (today, tomorrow, next week, etc.).
-- [ ] Footer hints are visible under both sections (Keychain storage note; long-press note for tap defaults).
 
 ## Known gaps
-- No "delete API key" button — user must clear the field and Save an empty string (not currently possible — Save is disabled on empty).
-- No per-tier "do not set due date" option.
+- No "delete API key" button — user must clear the field; Save is disabled on empty so clearing requires entering a blank then the Save button remains disabled.

--- a/Sources/PairwiseReminders/Views/HomeView.swift
+++ b/Sources/PairwiseReminders/Views/HomeView.swift
@@ -42,9 +42,6 @@ struct HomeView: View {
     @EnvironmentObject private var eloEngine: EloEngine
     @Environment(\.modelContext) private var modelContext
 
-    @AppStorage("home_tap_default") private var homeTapDefaultRaw: String = TapDefault.edit.rawValue
-    private var homeTapDefault: TapDefault { TapDefault(rawValue: homeTapDefaultRaw) ?? .edit }
-
     @Query private var allRecords: [RankedItemRecord]
 
     @State private var selectedList: EKCalendar?
@@ -219,7 +216,7 @@ struct HomeView: View {
                                 showHistory = true
                             }
                         } label: {
-                            Image(systemName: "ellipsis.circle")
+                            Image(systemName: "line.3.horizontal.decrease.circle")
                         }
                     }
                 }
@@ -387,7 +384,6 @@ struct HomeView: View {
                         .tag(item.id)
                         .contentShape(Rectangle())
                         .modifier(RowTapModifier(
-                            tapDefault: homeTapDefault,
                             isInSelectMode: editMode == .active,
                             onEdit: { editingItem = item },
                             onToggleSelect: { toggleSelection(item.id) }
@@ -398,7 +394,6 @@ struct HomeView: View {
                         .tag(item.id)
                         .contentShape(Rectangle())
                         .modifier(RowTapModifier(
-                            tapDefault: homeTapDefault,
                             isInSelectMode: editMode == .active,
                             onEdit: { editingItem = item },
                             onToggleSelect: { toggleSelection(item.id) }
@@ -428,7 +423,6 @@ struct HomeView: View {
                     .tag(item.id)
                     .contentShape(Rectangle())
                     .modifier(RowTapModifier(
-                        tapDefault: homeTapDefault,
                         isInSelectMode: editMode == .active,
                         onEdit: { editingItem = item },
                         onToggleSelect: { toggleSelection(item.id) }
@@ -443,7 +437,6 @@ struct HomeView: View {
                     .tag(item.id)
                     .contentShape(Rectangle())
                     .modifier(RowTapModifier(
-                        tapDefault: homeTapDefault,
                         isInSelectMode: editMode == .active,
                         onEdit: { editingItem = item },
                         onToggleSelect: { toggleSelection(item.id) }
@@ -478,7 +471,6 @@ struct HomeView: View {
                             .tag(item.id)
                             .contentShape(Rectangle())
                             .modifier(RowTapModifier(
-                                tapDefault: homeTapDefault,
                                 isInSelectMode: editMode == .active,
                                 onEdit: { editingItem = item },
                                 onToggleSelect: { toggleSelection(item.id) }
@@ -493,7 +485,6 @@ struct HomeView: View {
                             .tag(item.id)
                             .contentShape(Rectangle())
                             .modifier(RowTapModifier(
-                                tapDefault: homeTapDefault,
                                 isInSelectMode: editMode == .active,
                                 onEdit: { editingItem = item },
                                 onToggleSelect: { toggleSelection(item.id) }
@@ -630,31 +621,20 @@ struct HomeView: View {
 
 // MARK: - Row Tap Modifier
 
-/// Applies the user's configured tap-default to a reminder row.
-/// - In Select mode: tap toggles the List's built-in selection (we don't intercept).
-/// - Out of Select mode: tap and long-press bind to the configured primary/secondary actions.
 struct RowTapModifier: ViewModifier {
-    let tapDefault: TapDefault
     let isInSelectMode: Bool
     let onEdit: () -> Void
     let onToggleSelect: () -> Void
 
     func body(content: Content) -> some View {
-        // In Select mode, let the List's selection binding handle the tap.
         if isInSelectMode {
+            // Let the List's selection binding handle the tap; long-press opens edit.
             content
                 .simultaneousGesture(LongPressGesture(minimumDuration: 0.5).onEnded { _ in onEdit() })
         } else {
-            switch tapDefault {
-            case .edit:
-                content
-                    .onTapGesture { onEdit() }
-                    .simultaneousGesture(LongPressGesture(minimumDuration: 0.5).onEnded { _ in onToggleSelect() })
-            case .select:
-                content
-                    .onTapGesture { onToggleSelect() }
-                    .simultaneousGesture(LongPressGesture(minimumDuration: 0.5).onEnded { _ in onEdit() })
-            }
+            content
+                .onTapGesture { onEdit() }
+                .simultaneousGesture(LongPressGesture(minimumDuration: 0.5).onEnded { _ in onToggleSelect() })
         }
     }
 }
@@ -838,13 +818,10 @@ private struct CollapsedListHeader: View {
             let listColor = Color(cgColor: calendar.cgColor)
             HStack(alignment: .bottom, spacing: 2) {
                 ForEach(Array(rankedRecords.prefix(10).enumerated()), id: \.offset) { _, record in
-                    let h = 4.0 + 12.0 * ((record.eloRating - globalMin) / range)
-                    Capsule()
-                        .fill(listColor.opacity(0.75))
-                        .frame(width: 4, height: h)
+                    let fill = (record.eloRating - globalMin) / range
+                    SparklinePill(fill: fill, color: listColor)
                 }
             }
-            .frame(height: 16, alignment: .bottom)
         }
     }
 }
@@ -860,41 +837,17 @@ private struct ExpandedItemRow: View {
     /// Show the list name as a subtitle — useful in flat/date grouping modes.
     var showListName: Bool = false
 
-    @Environment(\.editMode) private var editMode
-
-    private var isSelecting: Bool { editMode?.wrappedValue == .active }
-
     private var eloStrength: Double {
         guard rank != nil, eloMax > eloMin else { return 0 }
         return max(0, min(1, (item.eloRating - eloMin) / (eloMax - eloMin)))
     }
 
-    private var barTint: Color {
-        if eloStrength > 0.66 { return .blue }
-        if eloStrength > 0.33 { return .indigo }
-        return Color(.systemGray3)
+    private var listColor: Color {
+        Color(cgColor: item.ekReminder.calendar?.cgColor ?? CGColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1))
     }
 
     var body: some View {
         HStack(spacing: 10) {
-            // Hide rank badge in selection mode — SwiftUI draws its own selection circle.
-            if !isSelecting {
-                if let r = rank {
-                    ZStack {
-                        Circle()
-                            .fill(badgeColor(r))
-                            .frame(width: 28, height: 28)
-                        Text("\(r)")
-                            .font(.system(.caption, design: .rounded).bold())
-                            .foregroundStyle(.white)
-                    }
-                } else {
-                    Circle()
-                        .strokeBorder(Color(.tertiaryLabel), lineWidth: 1.5)
-                        .frame(width: 26, height: 26)
-                }
-            }
-
             VStack(alignment: .leading, spacing: 3) {
                 Text(item.title)
                     .font(.subheadline)
@@ -906,25 +859,36 @@ private struct ExpandedItemRow: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
-
-                // Continuous Elo strength bar — only for ranked items
-                if rank != nil {
-                    ProgressView(value: eloStrength)
-                        .tint(barTint)
-                        .frame(height: 3)
-                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+
+            if rank != nil {
+                SparklinePill(fill: eloStrength, color: listColor)
+            }
         }
         .padding(.vertical, 2)
     }
+}
 
-    private func badgeColor(_ rank: Int) -> Color {
-        switch rank {
-        case 1: return .blue
-        case 2: return .indigo
-        case 3: return .purple
-        default: return Color(.systemGray3)
+// MARK: - Universal Sparkline Pill
+
+/// Fixed max-height capsule filled proportionally from the bottom — like a vertical battery.
+/// Use standalone for individual items, or combine in an HStack for list headers.
+struct SparklinePill: View {
+    let fill: Double   // 0.0–1.0
+    let color: Color
+    var width: CGFloat = 4
+    var height: CGFloat = 20
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            Capsule()
+                .fill(color.opacity(0.12))
+                .frame(width: width, height: height)
+            Capsule()
+                .fill(color.opacity(0.8))
+                .frame(width: width, height: max(width, CGFloat(fill) * height))
         }
+        .frame(width: width, height: height)
     }
 }

--- a/Sources/PairwiseReminders/Views/PairwiseView.swift
+++ b/Sources/PairwiseReminders/Views/PairwiseView.swift
@@ -2,44 +2,32 @@ import SwiftUI
 
 /// Tinder-style swipe UI for Elo-based pairwise comparisons.
 ///
-/// Both cards are identical in size and material — swipe the bottom card or tap either card
-/// to pick a winner. "Done for now" and Undo live in the navigation bar as glass pills.
+/// Both cards are swipeable with mirrored semantics: swipe right = this card wins,
+/// swipe left = other card wins. Tap either card to choose it; long-press to edit.
 struct PairwiseView: View {
 
     @EnvironmentObject private var session: PairwiseSession
     @EnvironmentObject private var engine: EloEngine
     @Environment(\.modelContext) private var modelContext
 
-    @AppStorage("pairwise_tap_default") private var pairwiseTapDefaultRaw: String = PairwiseTapDefault.choose.rawValue
-    private var pairwiseTapDefault: PairwiseTapDefault { PairwiseTapDefault(rawValue: pairwiseTapDefaultRaw) ?? .choose }
-
+    // Bottom card drag state
     @State private var dragOffset: CGSize = .zero
     @State private var exitOffset: CGFloat = 0
     @State private var isExiting: Bool = false
+
+    // Top card drag state
+    @State private var topDragOffset: CGSize = .zero
+    @State private var topExitOffset: CGFloat = 0
+    @State private var topIsExiting: Bool = false
+
     /// Randomly flipped each comparison so neither position is consistently favoured.
     @State private var isFlipped: Bool = false
     @State private var editingItem: ReminderItem?
 
     private let swipeThreshold: CGFloat = 100
 
-    private func primaryAction(for item: ReminderItem) {
-        switch pairwiseTapDefault {
-        case .choose: engine.choose(winner: item)
-        case .edit:   editingItem = item
-        }
-    }
-
-    private func secondaryAction(for item: ReminderItem) {
-        switch pairwiseTapDefault {
-        case .choose: editingItem = item
-        case .edit:   engine.choose(winner: item)
-        }
-    }
-
     var body: some View {
         VStack(spacing: 0) {
-            headerBar
-
             if let pair = engine.currentPair {
                 swipeContent(pair)
                     .id(engine.comparisonCount)
@@ -58,11 +46,19 @@ struct PairwiseView: View {
             }
         }
         .background(Color(.systemGroupedBackground).ignoresSafeArea())
+        .safeAreaInset(edge: .top, spacing: 0) {
+            progressBand
+        }
         .animation(.spring(response: 0.35, dampingFraction: 0.8), value: engine.comparisonCount)
         .onChange(of: engine.comparisonCount) { _, _ in
-            withAnimation(.spring(response: 0.3)) { dragOffset = .zero }
+            withAnimation(.spring(response: 0.3)) {
+                dragOffset = .zero
+                topDragOffset = .zero
+            }
             exitOffset = 0
             isExiting = false
+            topExitOffset = 0
+            topIsExiting = false
             isFlipped = Bool.random()
         }
         .onChange(of: engine.isConverged) { _, converged in
@@ -75,6 +71,7 @@ struct PairwiseView: View {
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
         }
+        .navigationTitle("Which matters more?")
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
@@ -95,6 +92,12 @@ struct PairwiseView: View {
                 .opacity(engine.canUndo ? 1 : 0.35)
             }
             ToolbarItem(placement: .topBarTrailing) {
+                Button { showSettingsSheet = true } label: {
+                    Image(systemName: "gear")
+                }
+                .accessibilityLabel("Settings")
+            }
+            ToolbarItem(placement: .topBarTrailing) {
                 Button {
                     session.finish(eloEngine: engine, context: modelContext)
                 } label: {
@@ -108,17 +111,17 @@ struct PairwiseView: View {
                 .buttonStyle(.plain)
             }
         }
+        .sheet(isPresented: $showSettingsSheet) {
+            SettingsView()
+        }
     }
 
-    // MARK: - Frosted Header
+    // MARK: - Progress Band (extends nav bar glass downward)
 
-    private var headerBar: some View {
+    private var progressBand: some View {
         VStack(spacing: 0) {
-            VStack(spacing: 8) {
+            VStack(spacing: 6) {
                 HStack {
-                    Text("Which matters more?")
-                        .font(.headline)
-                    Spacer()
                     Group {
                         if engine.estimatedRemaining > 0 {
                             Text("\(engine.estimatedRemaining) left")
@@ -128,8 +131,8 @@ struct PairwiseView: View {
                     }
                     .font(.caption.monospacedDigit())
                     .foregroundStyle(.secondary)
+                    Spacer()
                 }
-
                 ProgressView(
                     value: Double(engine.comparisonCount),
                     total: Double(max(engine.comparisonCount + engine.estimatedRemaining, 1))
@@ -137,26 +140,24 @@ struct PairwiseView: View {
                 .tint(.blue)
             }
             .padding(.horizontal, 16)
-            .padding(.vertical, 12)
-            .background(
-                RoundedRectangle(cornerRadius: 20, style: .continuous)
-                    .fill(.ultraThinMaterial)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 20, style: .continuous)
-                            .strokeBorder(Color.primary.opacity(0.08), lineWidth: 0.5)
-                    )
-            )
-            .padding(.horizontal, 16)
-            .padding(.top, 8)
+            .padding(.vertical, 8)
 
             if session.seedingFailed && session.mode != .pairwise {
                 Text("AI seeding unavailable — using default ratings")
                     .font(.caption2)
                     .foregroundStyle(.secondary)
-                    .padding(.top, 6)
+                    .padding(.bottom, 6)
             }
         }
+        .background(.ultraThinMaterial)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(Color.primary.opacity(0.08))
+                .frame(height: 0.5)
+        }
     }
+
+    @State private var showSettingsSheet = false
 
     // MARK: - Converged State
 
@@ -190,27 +191,41 @@ struct PairwiseView: View {
         return VStack(spacing: 0) {
             Spacer(minLength: 8)
 
-            // Top card — same size as bottom, tappable
-            Button { primaryAction(for: topItem) } label: {
-                PairwiseCardBody(item: topItem)
-            }
-            .buttonStyle(.plain)
-            .simultaneousGesture(LongPressGesture(minimumDuration: 0.5).onEnded { _ in secondaryAction(for: topItem) })
+            // Top card — swipeable: right = top wins, left = bottom wins
+            swipeCard(
+                item: topItem, versus: bottomItem,
+                dragOffset: $topDragOffset,
+                exitOffset: $topExitOffset,
+                isExiting: $topIsExiting
+            )
             .padding(.horizontal)
+            .simultaneousGesture(LongPressGesture(minimumDuration: 0.5).onEnded { _ in editingItem = topItem })
 
+            // About equal + vs separator
             HStack {
                 Spacer()
-                Text("vs")
-                    .font(.caption.bold())
-                    .foregroundStyle(.tertiary)
+                Button { engine.equal() } label: {
+                    Text("About equal")
+                        .font(.subheadline.weight(.medium))
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 8)
+                        .background(.regularMaterial, in: Capsule())
+                        .overlay(Capsule().strokeBorder(Color.primary.opacity(0.08), lineWidth: 0.5))
+                }
+                .buttonStyle(.plain)
                 Spacer()
             }
-            .padding(.vertical, 8)
+            .padding(.vertical, 10)
 
-            // Bottom card — swipeable
-            swipeCard(item: bottomItem, versus: topItem)
-                .padding(.horizontal)
-                .simultaneousGesture(LongPressGesture(minimumDuration: 0.5).onEnded { _ in secondaryAction(for: bottomItem) })
+            // Bottom card — swipeable: right = bottom wins, left = top wins
+            swipeCard(
+                item: bottomItem, versus: topItem,
+                dragOffset: $dragOffset,
+                exitOffset: $exitOffset,
+                isExiting: $isExiting
+            )
+            .padding(.horizontal)
+            .simultaneousGesture(LongPressGesture(minimumDuration: 0.5).onEnded { _ in editingItem = bottomItem })
 
             // Swipe direction hints
             HStack {
@@ -225,62 +240,56 @@ struct PairwiseView: View {
             .padding(.horizontal, 28)
             .padding(.top, 8)
 
-            // Equal button
-            Button { engine.equal() } label: {
-                Text("About equal")
-                    .font(.subheadline.weight(.medium))
-                    .padding(.horizontal, 28)
-                    .padding(.vertical, 11)
-                    .background(.regularMaterial, in: Capsule())
-                    .overlay(Capsule().strokeBorder(Color.primary.opacity(0.08), lineWidth: 0.5))
-            }
-            .buttonStyle(.plain)
-            .padding(.top, 8)
-
             Spacer(minLength: 20)
         }
     }
 
-    // MARK: - Swipe Card (bottom)
+    // MARK: - Swipe Card
 
-    private func swipeCard(item: ReminderItem, versus other: ReminderItem) -> some View {
-        let normalized = min(max(dragOffset.width / swipeThreshold, -1.0), 1.0)
+    private func swipeCard(
+        item: ReminderItem,
+        versus other: ReminderItem,
+        dragOffset: Binding<CGSize>,
+        exitOffset: Binding<CGFloat>,
+        isExiting: Binding<Bool>
+    ) -> some View {
+        let normalized = min(max(dragOffset.wrappedValue.width / swipeThreshold, -1.0), 1.0)
 
         return PairwiseCardBody(item: item)
             .overlay(swipeOverlay(normalized: normalized))
-            .rotationEffect(.degrees(Double(normalized) * 6))
-            .scaleEffect(1.0 - abs(normalized) * 0.06)
-            .offset(x: dragOffset.width * 0.5 + exitOffset)
-            .opacity(isExiting ? 0 : 1)
+            .rotationEffect(.degrees(Double(normalized) * 5))
+            .scaleEffect(1.0 - abs(normalized) * 0.04)
+            .offset(x: dragOffset.wrappedValue.width * 0.5 + exitOffset.wrappedValue)
+            .opacity(isExiting.wrappedValue ? 0 : 1)
             .gesture(
                 DragGesture(minimumDistance: 10)
-                    .onChanged { dragOffset = $0.translation }
+                    .onChanged { dragOffset.wrappedValue = $0.translation }
                     .onEnded { value in
                         let dx = value.translation.width
                         if dx > swipeThreshold {
-                            withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
-                                exitOffset = 900
-                                isExiting = true
+                            withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
+                                exitOffset.wrappedValue = 900
+                                isExiting.wrappedValue = true
                             }
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.22) {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                                 engine.choose(winner: item)
                             }
                         } else if dx < -swipeThreshold {
-                            withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
-                                exitOffset = -900
-                                isExiting = true
+                            withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
+                                exitOffset.wrappedValue = -900
+                                isExiting.wrappedValue = true
                             }
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.22) {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                                 engine.choose(winner: other)
                             }
                         } else {
                             withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
-                                dragOffset = .zero
+                                dragOffset.wrappedValue = .zero
                             }
                         }
                     }
             )
-            .onTapGesture { primaryAction(for: item) }
+            .onTapGesture { engine.choose(winner: item) }
     }
 
     @ViewBuilder
@@ -289,11 +298,11 @@ struct PairwiseView: View {
         if magnitude > 0.12 {
             let pickingThis = normalized > 0
             RoundedRectangle(cornerRadius: 22, style: .continuous)
-                .fill((pickingThis ? Color.green : Color.blue).opacity(magnitude * 0.3))
+                .fill((pickingThis ? Color.green : Color.blue).opacity(magnitude * 0.25))
                 .overlay(
                     VStack(spacing: 6) {
                         Image(systemName: pickingThis ? "hand.thumbsup.fill" : "arrow.up")
-                            .font(.system(size: 36, weight: .bold))
+                            .font(.system(size: 32, weight: .bold))
                             .foregroundStyle(pickingThis ? .green : .blue)
                         Text(pickingThis ? "This one" : "Top one")
                             .font(.caption.bold())
@@ -343,8 +352,8 @@ private struct PairwiseCardBody: View {
         .frame(maxWidth: .infinity, minHeight: 170)
         .background(
             RoundedRectangle(cornerRadius: 22, style: .continuous)
-                .fill(.regularMaterial)
-                .shadow(color: .black.opacity(0.1), radius: 16, y: 4)
+                .fill(Color(.secondarySystemBackground))
+                .shadow(color: .black.opacity(0.08), radius: 12, y: 3)
         )
     }
 }

--- a/Sources/PairwiseReminders/Views/ResultsView.swift
+++ b/Sources/PairwiseReminders/Views/ResultsView.swift
@@ -20,9 +20,6 @@ struct ResultsView: View {
     @State private var selectedForRefinement: Set<String> = []
     @State private var editModeValue: EditMode = .inactive
 
-    @AppStorage("home_tap_default") private var homeTapDefaultRaw: String = TapDefault.edit.rawValue
-    private var homeTapDefault: TapDefault { TapDefault(rawValue: homeTapDefaultRaw) ?? .edit }
-
     var body: some View {
         VStack(spacing: 0) {
             header
@@ -245,29 +242,17 @@ struct ResultsView: View {
     private func handlePrimaryTap(for item: ReminderItem) {
         if isSelectingForRefinement {
             toggleRefinementSelection(item.id)
-            return
-        }
-        switch homeTapDefault {
-        case .edit:
+        } else {
             detailItem = item
-        case .select:
-            isSelectingForRefinement = true
-            toggleRefinementSelection(item.id)
         }
     }
 
     private func handleSecondaryTap(for item: ReminderItem) {
-        // Long-press = opposite of primary.
         if isSelectingForRefinement {
             detailItem = item
-            return
-        }
-        switch homeTapDefault {
-        case .edit:
+        } else {
             isSelectingForRefinement = true
             toggleRefinementSelection(item.id)
-        case .select:
-            detailItem = item
         }
     }
 
@@ -362,8 +347,8 @@ private struct SessionRankedRow: View {
         maxRating > minRating ? (item.eloRating - minRating) / (maxRating - minRating) : 0.5
     }
 
-    var strengthColor: Color {
-        strength > 0.66 ? .blue : strength > 0.33 ? .indigo : Color(.systemGray3)
+    private var listColor: Color {
+        Color(cgColor: item.ekReminder.calendar?.cgColor ?? CGColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1))
     }
 
     var body: some View {
@@ -373,72 +358,36 @@ private struct SessionRankedRow: View {
                     .font(.title3)
                     .foregroundStyle(isSelected ? .blue : Color(.tertiaryLabel))
                     .frame(width: 28)
-            } else {
-                ZStack {
-                    Circle()
-                        .fill(badgeColor)
-                        .frame(width: 38, height: 38)
-                    Text("\(rank)")
-                        .font(.system(.body, design: .rounded).bold())
-                        .foregroundStyle(.white)
-                }
             }
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(item.title)
                     .font(.body)
                     .lineLimit(2)
-                Text(item.listName)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                if !isSelecting {
-                    ProgressView(value: strength)
-                        .tint(strengthColor)
-                        .frame(width: 80)
+                HStack(spacing: 4) {
+                    Text(item.listName)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    if let confidence = item.aiConfidence {
+                        Text("·")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text("\(confidence)%")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                    }
                 }
             }
 
             Spacer()
 
             if !isSelecting {
-                VStack(alignment: .trailing, spacing: 4) {
-                    Text(item.priorityLabel(totalCount: total))
-                        .font(.caption.bold())
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(priorityColor.opacity(0.15))
-                        .foregroundStyle(priorityColor)
-                        .clipShape(RoundedRectangle(cornerRadius: 6))
-
-                    if let confidence = item.aiConfidence {
-                        Text("\(confidence)%")
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                            .monospacedDigit()
-                    }
-                }
+                SparklinePill(fill: strength, color: listColor)
             }
         }
         .padding(.vertical, 4)
         .contentShape(Rectangle())
-    }
-
-    private var badgeColor: Color {
-        switch rank {
-        case 1: return .blue
-        case 2: return .indigo
-        case 3: return .purple
-        default: return Color(.systemGray3)
-        }
-    }
-
-    private var priorityColor: Color {
-        switch item.priorityColor(totalCount: total) {
-        case .high:   return .red
-        case .medium: return .orange
-        case .low:    return .yellow
-        case .none:   return Color(.secondaryLabel)
-        }
     }
 }
 
@@ -676,7 +625,7 @@ struct ApplySheet: View {
                 options.mediumDueTarget = session.defaultMediumDueTarget
                 options.lowDueTarget    = session.defaultLowDueTarget
             }
-            .navigationTitle("Apply to Reminders")
+            .navigationTitle("Apply")
             .navigationBarTitleDisplayMode(.inline)
             .toolbarBackground(.regularMaterial, for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)

--- a/Sources/PairwiseReminders/Views/SettingsView.swift
+++ b/Sources/PairwiseReminders/Views/SettingsView.swift
@@ -1,15 +1,5 @@
 import SwiftUI
 
-/// Tap-default on reminder rows (Home and Results screens).
-enum TapDefault: String, CaseIterable {
-    case edit, select
-}
-
-/// Tap-default on pairwise cards. Long-press performs the opposite.
-enum PairwiseTapDefault: String, CaseIterable {
-    case choose, edit
-}
-
 /// Settings tab: AI configuration and apply-sheet defaults.
 struct SettingsView: View {
 
@@ -28,33 +18,10 @@ struct SettingsView: View {
         NavigationStack {
             Form {
                 aiSection
-                interactionSection
                 dueDateDefaultsSection
             }
             .navigationTitle("Settings")
             .onAppear { loadSettings() }
-        }
-    }
-
-    // MARK: - Interaction Section
-
-    @AppStorage("home_tap_default") private var homeTapDefault: String = TapDefault.edit.rawValue
-    @AppStorage("pairwise_tap_default") private var pairwiseTapDefault: String = PairwiseTapDefault.choose.rawValue
-
-    private var interactionSection: some View {
-        Section {
-            Picker("Tap on a reminder", selection: $homeTapDefault) {
-                Text("Edit / Info").tag(TapDefault.edit.rawValue)
-                Text("Select").tag(TapDefault.select.rawValue)
-            }
-            Picker("Tap on a pairwise card", selection: $pairwiseTapDefault) {
-                Text("Choose").tag(PairwiseTapDefault.choose.rawValue)
-                Text("Edit / Info").tag(PairwiseTapDefault.edit.rawValue)
-            }
-        } header: {
-            Text("Interaction")
-        } footer: {
-            Text("Long-press always performs the opposite action.")
         }
     }
 


### PR DESCRIPTION
## Summary

- **Universal SparklinePill** — new shared component: fixed 4×20 capsule filled proportionally from the bottom (like a vertical battery). Replaces all variable-height bars in list headers (combined HStack) and individual item rows (single pill on right) across HomeView and ResultsView.
- **PairwiseView** — both cards now swipeable with mirrored semantics (right = this wins, left = other wins); "About equal" moved between the two cards; progress band integrates into nav bar glass via `safeAreaInset`; title is "Which matters more?"; card background changed to `secondarySystemBackground` for better light-mode contrast; gear icon added; tap always chooses / long-press always edits.
- **SettingsView** — removed Interaction section (TapDefault / PairwiseTapDefault enums and pickers); tap behaviour now auto-determined by select mode context.
- **HomeView** — `RowTapModifier` simplified (no tapDefault param); toolbar icon → `line.3.horizontal.decrease.circle`; rank-badge circles removed from rows.
- **ResultsView** — rank-badge circles and priority-label pills removed from rows; AI confidence shown inline with list name; ApplySheet title shortened to "Apply".

## Surfaces touched

- [x] `HomeView` → `Docs/Verification/Home.md`
- [x] `PairwiseView` → `Docs/Verification/Pairwise.md`
- [x] `ResultsView` → `Docs/Verification/Results.md`
- [x] `SettingsView` → `Docs/Verification/Settings.md`

## Test plan

- [ ] List headers show fixed-height sparkline pills (not variable bars); fills reflect relative Elo
- [ ] Item rows in HomeView show a single pill on the right; no rank badges
- [ ] PairwiseView: swipe top card right → top wins; swipe top card left → bottom wins (and vice versa for bottom card)
- [ ] "About equal" button sits between the two cards
- [ ] Progress + "N left" appear in the glass band immediately below the nav bar
- [ ] Card backgrounds are clearly visible in light mode
- [ ] Settings no longer has an Interaction section
- [ ] Tapping a reminder row always opens edit/detail; long-press enters select mode
- [ ] ResultsView rows: no numbered badges, no priority pills; sparkline pill on right
- [ ] AI confidence % appears for items seeded by AI
- [ ] Apply sheet title reads "Apply" (not "Apply to Reminders")
- [ ] Build succeeds: `xcodebuild … build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)