### PR TITLE
HIG compliance: Reduce Motion, VoiceOver labels, Dynamic Type icons

### DIFF
--- a/Docs/Verification/History.md
+++ b/Docs/Verification/History.md
@@ -1,6 +1,6 @@
 # Verification — History
 
-**Last verified:** 2026-04-19 against `7a291db`
+**Last verified:** 2026-04-19 against `206c92e`
 **Source:** `Sources/PairwiseReminders/Views/HistoryView.swift`
 **Related issues:** —
 
@@ -20,6 +20,7 @@ Compact log of every pairwise comparison decision, grouped by session and ordere
 - [ ] 100+ sessions — scroll is smooth; no excessive SwiftData fetch cost on open.
 - [ ] A reminder that has since been deleted — its history row still renders (stored title, not a live EventKit lookup).
 - [ ] Session with a single "equal" decision — decision label reads "Equal", not blank.
+- [ ] Empty-state clock icon scales with Dynamic Type up to Accessibility 2.
 
 ## Known gaps
 - No entry point from Home yet — navigation wiring TBD.

--- a/Docs/Verification/Home.md
+++ b/Docs/Verification/Home.md
@@ -1,6 +1,6 @@
 # Verification — Home
 
-**Last verified:** 2026-04-19 against `855b45e`
+**Last verified:** 2026-04-19 against `206c92e`
 **Source:** `Sources/PairwiseReminders/Views/HomeView.swift`
 **Related issues:** #101, #106, #114
 
@@ -32,6 +32,8 @@ The main landing screen: segmented mode picker (Lists / All Reminders / Due Date
 - [ ] Long reminder title (multiline) — row height grows; layout doesn't clip.
 - [ ] Section gap between list groups is tight (`.listSectionSpacing(.compact)`), not the default chunky iOS grouped inset.
 - [ ] Unranked items (comparisonCount == 0) show no sparkline pill.
+- [ ] VoiceOver reads the filter icon as "Group, sort, and history" (not the symbol name).
+- [ ] Empty-state clipboard icon scales with Dynamic Type up to Accessibility 2.
 
 ## Known gaps
 - Widget surface not yet built (tracked separately).

--- a/Docs/Verification/ListDetail.md
+++ b/Docs/Verification/ListDetail.md
@@ -1,6 +1,6 @@
 # Verification — List detail
 
-**Last verified:** 2026-04-19 against `7a291db`
+**Last verified:** 2026-04-19 against `206c92e`
 **Source:** `Sources/PairwiseReminders/Views/ListDetailView.swift`
 **Related issues:** —
 
@@ -21,6 +21,8 @@ This view may be supplanted by the Home "expand list" affordance — keep the ch
 - [ ] List with zero items — both sections render their empty states cleanly.
 - [ ] List with only unranked items — ranked section is hidden or shows an empty-state hint.
 - [ ] Back to Home reflects any reorderings made here (ranked sparkline updates).
+- [ ] VoiceOver reads the ellipsis toolbar button as "More options".
+- [ ] Empty-state checkmark icon scales with Dynamic Type up to Accessibility 2.
 
 ## Known gaps
 - No "run AI seeding" shortcut from this view.

--- a/Docs/Verification/Pairwise.md
+++ b/Docs/Verification/Pairwise.md
@@ -1,6 +1,6 @@
 # Verification — Pairwise comparison
 
-**Last verified:** 2026-04-19 against `855b45e`
+**Last verified:** 2026-04-19 against `206c92e`
 **Source:** `Sources/PairwiseReminders/Views/PairwiseView.swift`
 **Related issues:** #102, #115
 
@@ -34,6 +34,8 @@ The Tinder-style comparison screen: nav bar "Which matters more?" title + progre
 - [ ] Rapid-fire swipes — no stuck mid-transition state.
 - [ ] Session with exactly 2 items — one comparison, then converges.
 - [ ] Top and bottom card drag states are independent — dragging one card doesn't affect the other's position.
+- [ ] Respects `accessibilityReduceMotion`: card push transition becomes a plain opacity fade; swipe-out and comparison change use a short ease instead of spring.
+- [ ] "Ranking settled!" check icon and swipe overlay icons scale with Dynamic Type.
 
 ## Known gaps
 - No haptic feedback on choice (tracked separately).

--- a/Docs/Verification/PrioritiseStart.md
+++ b/Docs/Verification/PrioritiseStart.md
@@ -1,6 +1,6 @@
 # Verification — Prioritise start
 
-**Last verified:** 2026-04-19 against `7a291db`
+**Last verified:** 2026-04-19 against `206c92e`
 **Source:** `Sources/PairwiseReminders/Views/ListPickerView.swift`, `Sources/PairwiseReminders/Views/FilteringView.swift`, `PrioritiseOptionsSheet` in `HomeView.swift`
 **Related issues:** —
 
@@ -22,6 +22,7 @@ The flow that runs before `PairwiseView` opens: list picker (when entered withou
 - [ ] Pairwise-only mode + top-N — top-N is applied by existing Elo rating (from prior sessions), not AI seed rank.
 - [ ] Start Prioritise with fewer than 2 items in the selection — flow transitions to `.idle` silently (nothing to compare).
 - [ ] Criteria field blank — seeding still runs (criteria is optional).
+- [ ] Respects `accessibilityReduceMotion`: `FilteringView` status-line crossfade is suppressed. Sparkles icon scales with Dynamic Type.
 
 ## Known gaps
 - No visible "time remaining" during seeding — only a spinner.

--- a/Docs/Verification/Results.md
+++ b/Docs/Verification/Results.md
@@ -1,6 +1,6 @@
 # Verification — Results
 
-**Last verified:** 2026-04-19 against `855b45e`
+**Last verified:** 2026-04-19 against `206c92e`
 **Source:** `Sources/PairwiseReminders/Views/ResultsView.swift`
 **Related issues:** #103, #114
 
@@ -29,6 +29,7 @@ Ranked-list view shown after `PairwiseView` finishes or AI Only mode completes: 
 - [ ] Apply with a custom due date per tier — saves that exact date.
 - [ ] Top navigation bar uses `ultraThinMaterial`; floating glass buttons sit on a safe-area inset at the bottom.
 - [ ] Session stopped early — ranked items still show sparkline pills and confidence; Apply is available.
+- [ ] Respects `accessibilityReduceMotion`: "Applied to Reminders!" banner appears via ease instead of spring.
 
 ## Known gaps
 - No "undo apply" — if you apply wrong priorities, you must rerun.

--- a/Docs/Verification/Settings.md
+++ b/Docs/Verification/Settings.md
@@ -1,6 +1,6 @@
 # Verification — Settings
 
-**Last verified:** 2026-04-19 against `855b45e`
+**Last verified:** 2026-04-19 against `206c92e`
 **Source:** `Sources/PairwiseReminders/Views/SettingsView.swift`
 **Related issues:** #114
 
@@ -19,6 +19,7 @@ Sheet launched from the Home gear icon (and the Pairwise gear icon): Anthropic A
 - [ ] Bad API key (`sk-ant-invalid`) — Test connection surfaces an "Error 401" or similar with a readable message.
 - [ ] Offline — Test connection surfaces a network error message, not a spinner that hangs.
 - [ ] "Custom" due-date target is not offered in the pickers (filtered out) — only absolute buckets (today, tomorrow, next week, etc.).
+- [ ] VoiceOver announces the eye toggle as "Show API key" / "Hide API key" based on mask state.
 
 ## Known gaps
 - No "delete API key" button — user must clear the field; Save is disabled on empty so clearing requires entering a blank then the Save button remains disabled.

--- a/Sources/PairwiseReminders/Views/FilteringView.swift
+++ b/Sources/PairwiseReminders/Views/FilteringView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct FilteringView: View {
 
     @EnvironmentObject private var session: PairwiseSession
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @State private var statusLine = "Fetching reminders…"
 
@@ -18,7 +19,9 @@ struct FilteringView: View {
                     .fill(.blue.opacity(0.1))
                     .frame(width: 120, height: 120)
                 Image(systemName: "sparkles")
-                    .font(.system(size: 52, weight: .medium))
+                    .font(.largeTitle.weight(.medium))
+                    .imageScale(.large)
+                    .dynamicTypeSize(.small ... .accessibility2)
                     .foregroundStyle(.blue)
                     .symbolEffect(.variableColor.iterative)
             }
@@ -31,7 +34,7 @@ struct FilteringView: View {
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
-                    .animation(.easeInOut(duration: 0.3), value: statusLine)
+                    .animation(reduceMotion ? .none : .easeInOut(duration: 0.3), value: statusLine)
 
                 if let error = session.seedingError {
                     Text(error)

--- a/Sources/PairwiseReminders/Views/HistoryView.swift
+++ b/Sources/PairwiseReminders/Views/HistoryView.swift
@@ -44,7 +44,9 @@ struct HistoryView: View {
     private var emptyState: some View {
         VStack(spacing: 12) {
             Image(systemName: "clock.arrow.trianglehead.counterclockwise.rotate.90")
-                .font(.system(size: 44))
+                .font(.largeTitle)
+                .imageScale(.large)
+                .dynamicTypeSize(.small ... .accessibility2)
                 .foregroundStyle(.secondary)
             Text("No history yet")
                 .font(.title3.bold())

--- a/Sources/PairwiseReminders/Views/HomeView.swift
+++ b/Sources/PairwiseReminders/Views/HomeView.swift
@@ -218,6 +218,7 @@ struct HomeView: View {
                         } label: {
                             Image(systemName: "line.3.horizontal.decrease.circle")
                         }
+                        .accessibilityLabel("Group, sort, and history")
                     }
                 }
 
@@ -549,7 +550,9 @@ struct HomeView: View {
     private var emptyState: some View {
         VStack(spacing: 16) {
             Image(systemName: "list.bullet.clipboard")
-                .font(.system(size: 52))
+                .font(.largeTitle)
+                .imageScale(.large)
+                .dynamicTypeSize(.small ... .accessibility2)
                 .foregroundStyle(.secondary)
             Text("No Reminders Lists")
                 .font(.title2.bold())

--- a/Sources/PairwiseReminders/Views/ListDetailView.swift
+++ b/Sources/PairwiseReminders/Views/ListDetailView.swift
@@ -124,7 +124,9 @@ struct ListDetailView: View {
     private var emptyState: some View {
         VStack(spacing: 12) {
             Image(systemName: "checkmark.circle")
-                .font(.system(size: 48))
+                .font(.largeTitle)
+                .imageScale(.large)
+                .dynamicTypeSize(.small ... .accessibility2)
                 .foregroundStyle(.secondary)
             Text("All done!")
                 .font(.title2.bold())
@@ -156,6 +158,7 @@ struct ListDetailView: View {
             } label: {
                 Image(systemName: "ellipsis.circle")
             }
+            .accessibilityLabel("More options")
         }
     }
 

--- a/Sources/PairwiseReminders/Views/PairwiseView.swift
+++ b/Sources/PairwiseReminders/Views/PairwiseView.swift
@@ -9,6 +9,7 @@ struct PairwiseView: View {
     @EnvironmentObject private var session: PairwiseSession
     @EnvironmentObject private var engine: EloEngine
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     // Bottom card drag state
     @State private var dragOffset: CGSize = .zero
@@ -31,10 +32,12 @@ struct PairwiseView: View {
             if let pair = engine.currentPair {
                 swipeContent(pair)
                     .id(engine.comparisonCount)
-                    .transition(.asymmetric(
-                        insertion: .push(from: .trailing).combined(with: .opacity),
-                        removal:   .push(from: .leading).combined(with: .opacity)
-                    ))
+                    .transition(reduceMotion
+                        ? .opacity
+                        : .asymmetric(
+                            insertion: .push(from: .trailing).combined(with: .opacity),
+                            removal:   .push(from: .leading).combined(with: .opacity)
+                        ))
             } else if engine.isConverged {
                 convergedState
             } else {
@@ -49,7 +52,7 @@ struct PairwiseView: View {
         .safeAreaInset(edge: .top, spacing: 0) {
             progressBand
         }
-        .animation(.spring(response: 0.35, dampingFraction: 0.8), value: engine.comparisonCount)
+        .animation(reduceMotion ? .easeInOut(duration: 0.15) : .spring(response: 0.35, dampingFraction: 0.8), value: engine.comparisonCount)
         .onChange(of: engine.comparisonCount) { _, _ in
             withAnimation(.spring(response: 0.3)) {
                 dragOffset = .zero
@@ -165,7 +168,9 @@ struct PairwiseView: View {
         VStack(spacing: 16) {
             Spacer()
             Image(systemName: "checkmark.seal.fill")
-                .font(.system(size: 52))
+                .font(.largeTitle)
+                .imageScale(.large)
+                .dynamicTypeSize(.small ... .accessibility2)
                 .foregroundStyle(.blue)
             Text("Ranking settled!")
                 .font(.title2.bold())
@@ -267,7 +272,7 @@ struct PairwiseView: View {
                     .onEnded { value in
                         let dx = value.translation.width
                         if dx > swipeThreshold {
-                            withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
+                            withAnimation(reduceMotion ? .easeOut(duration: 0.15) : .spring(response: 0.35, dampingFraction: 0.8)) {
                                 exitOffset.wrappedValue = 900
                                 isExiting.wrappedValue = true
                             }
@@ -275,7 +280,7 @@ struct PairwiseView: View {
                                 engine.choose(winner: item)
                             }
                         } else if dx < -swipeThreshold {
-                            withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
+                            withAnimation(reduceMotion ? .easeOut(duration: 0.15) : .spring(response: 0.35, dampingFraction: 0.8)) {
                                 exitOffset.wrappedValue = -900
                                 isExiting.wrappedValue = true
                             }
@@ -302,7 +307,8 @@ struct PairwiseView: View {
                 .overlay(
                     VStack(spacing: 6) {
                         Image(systemName: pickingThis ? "hand.thumbsup.fill" : "arrow.up")
-                            .font(.system(size: 32, weight: .bold))
+                            .font(.title.bold())
+                            .dynamicTypeSize(.small ... .accessibility1)
                             .foregroundStyle(pickingThis ? .green : .blue)
                         Text(pickingThis ? "This one" : "Top one")
                             .font(.caption.bold())

--- a/Sources/PairwiseReminders/Views/ResultsView.swift
+++ b/Sources/PairwiseReminders/Views/ResultsView.swift
@@ -9,6 +9,7 @@ struct ResultsView: View {
     @EnvironmentObject private var remindersManager: RemindersManager
     @EnvironmentObject private var eloEngine: EloEngine
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @State private var showApplySheet = false
     @State private var showHistory = false
@@ -151,7 +152,7 @@ struct ResultsView: View {
                     .transition(.move(edge: .top).combined(with: .opacity))
             }
         }
-        .animation(.spring(response: 0.4), value: applied)
+        .animation(reduceMotion ? .easeInOut(duration: 0.2) : .spring(response: 0.4), value: applied)
     }
 
     // MARK: - Ranked List
@@ -325,7 +326,7 @@ struct ResultsView: View {
             if options.applyFlags {
                 try remindersManager.applyFlags(items, count: options.flagCount)
             }
-            withAnimation(.spring(response: 0.4)) { applied = true }
+            withAnimation(reduceMotion ? .easeInOut(duration: 0.2) : .spring(response: 0.4)) { applied = true }
         } catch {
             applyError = error.localizedDescription
         }

--- a/Sources/PairwiseReminders/Views/SettingsView.swift
+++ b/Sources/PairwiseReminders/Views/SettingsView.swift
@@ -46,6 +46,7 @@ struct SettingsView: View {
                     Image(systemName: apiKeyMasked ? "eye" : "eye.slash")
                         .foregroundStyle(.secondary)
                 }
+                .accessibilityLabel(apiKeyMasked ? "Show API key" : "Hide API key")
                 Button("Save") {
                     saveAPIKey()
                 }


### PR DESCRIPTION
Addresses both High-severity HIG findings plus the Medium hardcoded-icon-size issue. Animations on swipe cards, comparison transitions, and applied banners now fall back to short eases (or opacity fades) when Reduce Motion is enabled. Icon-only toolbar buttons (Home filter menu, ListDetail ellipsis, Settings eye toggle) gain accessibility labels. Empty-state and affordance icons across six views now scale with Dynamic Type via .largeTitle + .imageScale(.large) + .dynamicTypeSize bounds.

## Summary

<!-- 1–3 bullets. What changed and why. -->

## Surfaces touched

Tick every surface this PR changes. Each tick **must** correspond to an update in the matching verification doc (even if the update is just bumping `Last verified`).

- [ ] Bootstrap — `Docs/Verification/Bootstrap.md`
- [ ] Home — `Docs/Verification/Home.md`
- [ ] Prioritise start — `Docs/Verification/PrioritiseStart.md`
- [ ] Pairwise — `Docs/Verification/Pairwise.md`
- [ ] Results — `Docs/Verification/Results.md`
- [ ] List detail — `Docs/Verification/ListDetail.md`
- [ ] Settings — `Docs/Verification/Settings.md`
- [ ] History — `Docs/Verification/History.md`
- [ ] None of the above (no user-visible change)

If none of the surfaces apply, add the opt-out line (and the `Verification sync` check will pass):

```
[verification: n/a — <one-line reason>]
```

## Test plan

<!-- What you actually ran. Simulator? Device? Specific checklist items from the verification doc? -->

- [ ] Ran relevant checklist(s) in `Docs/Verification/` on an iOS 26 simulator
- [ ] Bumped `Last verified` on touched docs

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
